### PR TITLE
Dalas acheivements.cfg adjustments

### DIFF
--- a/achievements.cfg
+++ b/achievements.cfg
@@ -6,64 +6,64 @@
 
     [achievement]
         id=ad_strong
-        name= _ "Bazur the Strong"
-        description= _ "Get a <i>strong</i> trait for Bazur in <i>Orcish Comradery</i> scenario"
+        name= _ "Scenario 1: Bazur the Strong"
+        description= _ "Earn the <i>strong</i> trait on Bazur in <i>Orcish Comradery</i>"
         icon="data/core/images/units/orcs/leader-attack-2.png~RC(magenta>white)"
         icon_completed="data/core/images/units/orcs/leader-attack-2.png~RC(magenta>white)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]
 
     [achievement]
         id=ad_leaderkill
-        name= _ "An Orcish Competition"
-        description= _ "Kill <i>strong</i> orcish leader in <i>Welcome to Wesnoth</i> scenario"
+        name= _ "Scenario 2: A Friendly Competition"
+        description= _ "Kill the orcish leader in <i>Welcome to Wesnoth</i>"
         icon="data/core/images/items/gold-coins-small.png"
         icon_completed="data/core/images/items/gold-coins-small.png~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]
 
     [achievement]
         id=ad_training
-        name= _ "Battle Training"
-        description= _ "Get a <i>trained</i> trait in <i>A Prophecy of the Royal Forest</i> scenario"
+        name= _ "Scenario 4: Battle Training"
+        description= _ "Earn the special <i>trained</i> trait in <i>A Prophecy of the Royal Forest</i>"
         icon="data/core/images/items/dummy.png~RC(magenta>red)"
         icon_completed="data/core/images/items/dummy.png~RC(magenta>red)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]
 
     [achievement]
         id=ad_dark_queen
-        name= _ "Dark Queen Rising"
-        description= _ "Advance Asheviere in <i>The Art of War</i> scenario"
+        name= _ "Scenario 6: Dark Queen Rising"
+        description= _ "Advance Asheviere to level 4 in <i>The Art of War</i>"
         icon="data/campaigns/Heir_To_The_Throne/images/units/human-queen.png~RC(magenta>red)"
         icon_completed="data/campaigns/Heir_To_The_Throne/images/units/human-queen.png~RC(magenta>red)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]
 
     [achievement]
         id=ad_ants
-        name= _ "Peacemaker"
-        description= _ "Kill one of enemy leaders in <i>An Underground Feud</i>"
+        name= _ "Scenario 7: Peacemaker"
+        description= _ "Squash one of the warring leaders in <i>An Underground Feud</i>"
         icon="data/core/images/items/sword.png"
         icon_completed="data/core/images/items/sword.png~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]
 
     [achievement]
         id=ad_offical
-        name= _ "Queen's Officals"
-        description= _ "Open all of gates with a human unit in <i>The End of the War</i> scenario"
+        name= _ "Scenario 8: Queen's Officals"
+        description= _ "Open all gates with human units in <i>The End of the War</i>"
         icon="data/core/images/items/key2.png"
         icon_completed="data/core/images/items/key2.png~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]
 
     [achievement]
         id=ad_armour
-        name= _ "Not so Magnificent Armour"
-        description= _ "Defeat the Baron Richard by ranged pierce or blade attack"
+        name= _ "Scenario 8: Not-so-Magnificent Armour"
+        description= _ "Defeat Baron Richard with a ranged pierce or blade attack"
         icon="data/core/images/items/armor.png"
         icon_completed="data/core/images/items/armor.png~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]
 
     [achievement]
         id=ad_bonus
-        name= _ "An Unexpected Prequel"
-        description= _ "Get all the achievements and pass bonus scenario"
+        name= _ "Bonus Scenarios: An Unexpected Prequel"
+        description= _ "Get all other achievements to unlock and complete the bonus scenarios!"
         icon="data/add-ons/Ashievieres_Dogs/images/misc/lisar_icon.png"
         icon_completed="data/add-ons/Ashievieres_Dogs/images/misc/lisar_icon.png~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]


### PR DESCRIPTION
Reworded some achievements for better clarity.

TSG and TDG had 1 achievement for each scenario, so I think it's important to show the scenario number in AD so that players realize some scenarios have 2 achievements and others have 0.