### PR TITLE
Dalas S01 storytext adjustment

### DIFF
--- a/scenarios/01_Orcish_Comradery.cfg
+++ b/scenarios/01_Orcish_Comradery.cfg
@@ -31,7 +31,7 @@
 
     [story]
         [part]
-            story=_"With two kings dead in as many months, the Kingdom of Wesnoth stood in crisis."
+            story=_"With two kings dead in as many weeks, the Kingdom of Wesnoth stood in crisis."
             {AD_BIGMAP}
         [/part]
         [part]

--- a/scenarios/01_Orcish_Comradery.cfg
+++ b/scenarios/01_Orcish_Comradery.cfg
@@ -31,23 +31,23 @@
 
     [story]
         [part]
-            story=_"501 YW. While engaged in battle against an orcish host, King Garard II was betrayed and murdered by his son, Prince Eldred. After appeasing the orcs with a tribute of gold, the prince with his army of traitors marched confidently home to declare himself king."
+            story=_"With two kings dead in as many months, the Kingdom of Wesnoth stood in crisis."
+            {AD_BIGMAP}
+        [/part]
+        [part]
+            story=_"Garard II had been betrayed and murdered by his son Eldred, who was himself then felled by Delfador — the late king’s arch-mage."
             background=story/httt_story2.jpg
         [/part]
         [part]
-            story=_"Yet, on the outskirts of the capital, there stood against him the court mage Delfador and many noble lords loyal to his father's memory. A fierce struggle ensued and Prince Eldred fell at the hands of Delfador the Great."
-            background=story/httt_story4.jpg
-        [/part]
-        [part]
-            story=_"Knowing their most terrible crime left no hope for leniency, the forces of the slain prince were quick to rally around his mother, Queen Asheviere, and held strong until their opposition was narrowly routed. Then, with ruthless haste, Asheviere disposed of Garard's young nephews and took the throne of Wesnoth for herself. To any who would support her claim she granted unprecedented new privileges, and in this way she garnered support from the Clans of the Great Plains."
+            story=_"Knowing their most terrible crime left no hope for leniency, Eldred’s remaining supporters were quick to rally around his mother — the Queen Asheviere. With ruthless haste, Asheviere disposed of Garard’s young nephews and declared herself High Queen of Wesnoth."
             {AD_BIGMAP}
         [/part]
         [part]
-            story=_"The opposing lords, in turn, retreated to their domains and began assembling an army great enough to all but ensure the usurper's overthrow. Indeed, the queen's position was dire, for though she controlled the province of Weldyn, rebel banners rose swiftly over Soradoc, Tath, and Dan-Tonk. Encircled and soon to be outnumbered, Asheviere devised a cunning plan."
-            {AD_BIGMAP}
+            story=_"In turn, many nobles loyal to Garard’s memory rallied together and began assembling an army great enough to all but ensure the usurper’s overthrow. Indeed, the queen’s position was dire, for though she controlled the province of Weldyn, rebel banners rose swiftly over the strongholds of Soradoc and Dan-Tonk. Encircled and soon to be outnumbered, Asheviere devised a cunning plan."
+            background=story/landscape-hills-02.webp
         [/part]
         [part]
-            story=_"She sent messengers north beyond the Great River to enlist the support of previously unimaginable allies..."
+            story=_"Mere days after Eldred’s death, she dispatched messengers north beyond the Great River to enlist the support of previously unimaginable allies..."
             {AD_BIGMAP}
         [/part]
     [/story]

--- a/scenarios/01_Orcish_Comradery.cfg
+++ b/scenarios/01_Orcish_Comradery.cfg
@@ -43,7 +43,7 @@
             {AD_BIGMAP}
         [/part]
         [part]
-            story=_"In turn, many nobles loyal to Garard’s memory rallied together and began assembling an army great enough to all but ensure the usurper’s overthrow. Indeed, the queen’s position was dire, for though she controlled the province of Weldyn, rebel banners rose swiftly over the strongholds of Soradoc and Dan-Tonk. Encircled and soon to be outnumbered, Asheviere devised a cunning plan."
+            story=_"In turn, lords loyal to Garard’s memory rallied together and began assembling an army great enough to all but ensure the usurper’s overthrow. Indeed, the queen’s position was dire, for though she controlled the province of Weldyn, rebel banners rose swiftly over the strongholds of Soradoc and Dan-Tonk. Encircled and soon to be outnumbered, Asheviere devised a cunning plan."
             background=story/landscape-hills-02.webp
         [/part]
         [part]


### PR DESCRIPTION
To try and stay consistent with events as told in TDG, as well as the "cursed army" from Liberty.

Deliberately staying vague as to who won TDG's ending battle, so that we don't contradict the player's gameplay - they might have barely assassinated Eldred, or they might have wiped out his entire army.