### PR TITLE
Use Curly Apostrophes

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -7,7 +7,7 @@
 [campaign]
     id=Ashevieres_Dogs
     icon="data/campaigns/Heir_To_The_Throne/images/units/human-queen.png"
-    name= _"Asheviere's Dogs"
+    name= _"Asheviere’s Dogs"
     abbrev= _ "AD"
     rank=303
     start_year="501 YW"

--- a/_main.cfg
+++ b/_main.cfg
@@ -13,7 +13,7 @@
     start_year="501 YW"
     end_year="501 YW"
     define=ASHEVIERES_DOGS
-    description=_ "Go through the crucible of civil war and help the Queen Asheviere assert her power during some of the darkest times in Wesnoth's history!
+    description=_ "Go through the crucible of civil war and help the Queen Asheviere assert her power during some of the darkest times in Wesnoth’s history!
     
 (Intermediate level, 8 scenarios)"
     first_scenario=01_Orcish_Comradery

--- a/achievements.cfg
+++ b/achievements.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-AD
 
 [achievement_group]
-    display_name=_"Asheviere's Dogs"
+    display_name=_"Asheviere’s Dogs"
     content_for=ashevieres_dogs
 
     [achievement]

--- a/achievements.cfg
+++ b/achievements.cfg
@@ -46,7 +46,7 @@
 
     [achievement]
         id=ad_offical
-        name= _ "Scenario 8: Queen's Officals"
+        name= _ "Scenario 8: Queen’s Officals"
         description= _ "Open all gates with human units in <i>The End of the War</i>"
         icon="data/core/images/items/key2.png"
         icon_completed="data/core/images/items/key2.png~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"

--- a/scenarios/01_Orcish_Comradery.cfg
+++ b/scenarios/01_Orcish_Comradery.cfg
@@ -129,7 +129,7 @@
         share_vision=all
         type=Orcish Warrior
         id=Warlord_Troll
-        name=_ "Hu'ug"
+        name=_ "Hu’ug"
         profile="portraits/orcs/grunt-2.webp"
         [modifications]
             {TRAIT_STRONG}
@@ -275,7 +275,7 @@
         recruit=
         color=red
         team_name=wesnothians
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT loyalist}
 
         [ai]
@@ -452,7 +452,7 @@
         [message]
             speaker=narrator
             image="wesnoth-icon.png"
-            message=_ "In the second month of Asheviere's reign, a messenger from Wesnoth arrived in the lands of Whitefang clan..."
+            message=_ "In the second month of Asheviere’s reign, a messenger from Wesnoth arrived in the lands of Whitefang clan..."
         [/message]
 
         [unit]
@@ -505,12 +505,12 @@
 
         [message]
             speaker=Warlord_Assassin
-            message=_ "Ha! Only a fool'd serve those they just kicked in the ass!"
+            message=_ "Ha! Only a fool’d serve those they just kicked in the ass!"
         [/message]
 
         [message]
             speaker=Bazur
-            message=_ "I'll do it. I'll go... even though I'm not a fool."
+            message=_ "I’ll do it. I’ll go... even though I’m not a fool."
         [/message]
 
         [message]
@@ -525,12 +525,12 @@
 
         [message]
             speaker=Warlord_Assassin
-            message=_ "You jealous worm, the High Chief has divided the tribute based on merit. Don't even think about dishonoring the Whitefangs, you're not going anywhere!"
+            message=_ "You jealous worm, the High Chief has divided the tribute based on merit. Don’t even think about dishonoring the Whitefangs, you’re not going anywhere!"
         [/message]
 
         [message]
             speaker=Bazur
-            message=_ "That's not for you swine to decide."
+            message=_ "That’s not for you swine to decide."
         [/message]
 
         [message]
@@ -550,7 +550,7 @@
 
         [message]
             speaker=Warlord_Troll
-            message=_ "No way! Grunts, don't let the bastard get away!"
+            message=_ "No way! Grunts, don’t let the bastard get away!"
         [/message]
 
         [message]
@@ -561,7 +561,7 @@
         [message]
             speaker=Bazur
             [option]
-                    label=_ "Send them against Hu'ug! (blue chief)"
+                    label=_ "Send them against Hu’ug! (blue chief)"
                     [command]
                         {MODIFY_AI_ADD_GOAL 4 (
                         [goal]
@@ -597,7 +597,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "I bet some of my neighbours' underlings would join me if they could. Maybe I should slaughter those pigs Hu'ug and Ruksha to gain more backers."
+            message=_ "I bet some of my neighbours’ underlings would join me if they could. Maybe I should slaughter those pigs Hu’ug and Ruksha to gain more backers."
         [/message]
         
         [objectives]
@@ -617,7 +617,7 @@
                             id=Warlord_Troll
                         [/have_unit]
                     [/show_if]
-                    description= _ "Killing Hu'ug will give you a unique Orcish Grunt and a Troll Whelp"
+                    description= _ "Killing Hu’ug will give you a unique Orcish Grunt and a Troll Whelp"
                     condition=win
                 [/objective]
                 [objective]
@@ -634,7 +634,7 @@
                     condition=lose
                 [/objective]
                 [objective]
-                    description= _ "Death of Wesnoth's Messenger"
+                    description= _ "Death of Wesnoth’s Messenger"
                     condition=lose
                 [/objective]
                 {TURNS_RUN_OUT}
@@ -660,7 +660,7 @@
 
         [message]
             speaker=messenger
-            message=_ "Well done. Be sure you'll earn far more in Asheviere's service than in any of your raids."
+            message=_ "Well done. Be sure you’ll earn far more in Asheviere’s service than in any of your raids."
         [/message]
 
         [message]
@@ -731,7 +731,7 @@
 
         [message]
             speaker=Grump
-            message=_ "Hu'ug was bad chief. We go with Bazur!"
+            message=_ "Hu’ug was bad chief. We go with Bazur!"
         [/message]
 
     [/event]
@@ -745,7 +745,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "Who's the fool now?"
+            message=_ "Who’s the fool now?"
         [/message]
         [message]
             speaker=unit
@@ -846,7 +846,7 @@
 
         [message]
             speaker=second_unit
-            message=_ "The messenger is dead! Now Bazur the Worm has nowhere to go, and his minions won't get any more than we do!"
+            message=_ "The messenger is dead! Now Bazur the Worm has nowhere to go, and his minions won’t get any more than we do!"
         [/message]
 
         [message]

--- a/scenarios/02_Welcome_to_Wesnoth.cfg
+++ b/scenarios/02_Welcome_to_Wesnoth.cfg
@@ -109,7 +109,7 @@
         {BAZUR_ARC_I}
         color=white
         team_name=bazur
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         save_id=bazur
         {FLAG_VARIANT ragged}
     [/side]
@@ -124,7 +124,7 @@
         gold=200
         income=7
         team_name=Queen,bazur
-        user_team_name=_"Asheviere's Forces"
+        user_team_name=_"Asheviere’s Forces"
 
         {FLAG_VARIANT loyalist}
 
@@ -138,7 +138,7 @@
 
         [unit]
             type=Royal Guard
-            name=_ "Queen's Bodyguard" 
+            name=_ "Queen’s Bodyguard" 
             x,y=9,34 
             ai_special=guardian
             [modifications]
@@ -149,7 +149,7 @@
 
         [unit]
             type=Royal Guard
-            name=_ "Queen's Bodyguard" 
+            name=_ "Queen’s Bodyguard" 
             x,y=11,34 
             ai_special=guardian
             [modifications]
@@ -192,7 +192,7 @@
         hidden=yes
         color=blue
         team_name=Queen
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT ragged}
     [/side]
 
@@ -401,7 +401,7 @@
         
 	    [message]
             speaker=Bazur
-            message=_ "Hah, the humans really are fighting each other! We must show this queen our strength by slaughtering her enemy's leader with our own hands. Time to set up camp!"
+            message=_ "Hah, the humans really are fighting each other! We must show this queen our strength by slaughtering her enemy’s leader with our own hands. Time to set up camp!"
         [/message]
 
         [animate_unit]

--- a/scenarios/03_The_Iron_Hunt.cfg
+++ b/scenarios/03_The_Iron_Hunt.cfg
@@ -21,17 +21,17 @@
 
     [story]
         [part]
-            story=_"The first battle under Asheviere's banner was a great success for the orcs of Bazur. Not only had they plundered Soradoc during the assault, but afterwards were richly rewarded from the Queen's coffers. Eagerly, they awaited their next task."
+            story=_"The first battle under Asheviere’s banner was a great success for the orcs of Bazur. Not only had they plundered Soradoc during the assault, but afterwards were richly rewarded from the Queen’s coffers. Eagerly, they awaited their next task."
             {AD_BIGMAP}
             {JOURNEY_02_OLD}
         [/part]
         [part]
-            story=_"Isolde, who accompanied them, was the widow of a knight who had died at the crossing of Abez. As Isolde was of a lowly family, her husband's estate was to go to his relatives, and she was to be left with nothing. To prevent this, she strove to earn her knighthood."
+            story=_"Isolde, who accompanied them, was the widow of a knight who had died at the crossing of Abez. As Isolde was of a lowly family, her husband’s estate was to go to his relatives, and she was to be left with nothing. To prevent this, she strove to earn her knighthood."
             {AD_BIGMAP}
             {JOURNEY_02_OLD}
         [/part]
         [part]
-            story=_"Both the orcs and Isolde had their reasons for moving relentlessly. Soon enough, they caught up with the rebel's detachment of heavy infantry..."
+            story=_"Both the orcs and Isolde had their reasons for moving relentlessly. Soon enough, they caught up with the rebel’s detachment of heavy infantry..."
             {AD_BIGMAP}
             {JOURNEY_02_OLD}
         [/part]
@@ -41,7 +41,7 @@
 
     [label]
         x,y=7,9
-        text=_ "Glyn's Forest"
+        text=_ "Glyn’s Forest"
         immutable=yes
     [/label]
 
@@ -56,7 +56,7 @@
         {BAZUR_ARC_I}
         color=white
         team_name=bazur
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT ragged}
         save_id=bazur
     [/side]
@@ -337,12 +337,12 @@
 
         [message]
             speaker=Isolde
-            message=_ "There they are! I can't believe the Baron has a whole troop of heavy infantry left; I thought the war had exhausted all his reserves! Funny how “destitute” lords suddenly find more soldiers once they see an opportunity to take power..."
+            message=_ "There they are! I can’t believe the Baron has a whole troop of heavy infantry left; I thought the war had exhausted all his reserves! Funny how “destitute” lords suddenly find more soldiers once they see an opportunity to take power..."
         [/message]
 
         [message]
             speaker=Bazur
-            message=_ "Hey, I thought we'd chopped all you guys down! Get ready for some more chopping!"
+            message=_ "Hey, I thought we’d chopped all you guys down! Get ready for some more chopping!"
         [/message]
 
         [message]
@@ -357,7 +357,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "No, wait! We can't just attack a whole squad of heavies head-on!"
+            message=_ "No, wait! We can’t just attack a whole squad of heavies head-on!"
         [/message]
 
         [message]
@@ -367,7 +367,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "I take it you never took a heavy's mace to the head before! You'd be wiser for it if you had."
+            message=_ "I take it you never took a heavy’s mace to the head before! You’d be wiser for it if you had."
         [/message]
 
         [message]
@@ -393,7 +393,7 @@
         [message]
             scroll=no
             speaker=Isolde
-            message=_ "Their route takes them past a fort that belonged to Sir Elec. Though Soradoc has fallen, I'm sure the fort is still occupied by rebels. We must take it as our launching point against the heavies."
+            message=_ "Their route takes them past a fort that belonged to Sir Elec. Though Soradoc has fallen, I’m sure the fort is still occupied by rebels. We must take it as our launching point against the heavies."
         [/message]
 
         [scroll_to]
@@ -409,7 +409,7 @@
         [message]
             scroll=no
             speaker=Isolde
-            message=_ "Then they shall have to ford a river. It's not deep, but with their armor it's a serious obstacle. We should give them a fight on the bridge, where they cannot bring their full strength to bear, and if they try for a water crossing we can pick them off more easily."
+            message=_ "Then they shall have to ford a river. It’s not deep, but with their armor it’s a serious obstacle. We should give them a fight on the bridge, where they cannot bring their full strength to bear, and if they try for a water crossing we can pick them off more easily."
         [/message]
 
         [remove_shroud]
@@ -423,12 +423,12 @@
         [message]
             scroll=no
             speaker=Isolde
-            message=_ "The key is to keep them from reaching the end of the road. From there, it's only a short march to Tath. If the heavies reinforce its garrison, Asheviere will be furious. I don't want to incur her wrath, and neither do you, believe me."
+            message=_ "The key is to keep them from reaching the end of the road. From there, it’s only a short march to Tath. If the heavies reinforce its garrison, Asheviere will be furious. I don’t want to incur her wrath, and neither do you, believe me."
         [/message]
 
         [message]
             speaker=Bazur
-            message=_ "Of course not. She wouldn't pay."
+            message=_ "Of course not. She wouldn’t pay."
         [/message]
 
         [message]
@@ -438,7 +438,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "Like you're not fighting for gold!"
+            message=_ "Like you’re not fighting for gold!"
         [/message]
 
         [message]
@@ -448,7 +448,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "There's nothing to repeat! Take the fort, intercept at the bridge, don't let them get to the end of the road! Let's do it!"
+            message=_ "There’s nothing to repeat! Take the fort, intercept at the bridge, don’t let them get to the end of the road! Let’s do it!"
         [/message]
 
         [object] 
@@ -556,7 +556,7 @@
 
         [message]
             speaker=Isolde
-            message= _ "The infantrymen are exhausted! Let's take advantage of that and strike!"
+            message= _ "The infantrymen are exhausted! Let’s take advantage of that and strike!"
         [/message]
     [/event]
 
@@ -623,7 +623,7 @@
 
             [message]
                 speaker=desertir1 
-                message=_ "...It doesn't matter who killed Garard, we don't care what's going on in the palace. We did our duty, we defended the crown as best we could, no matter that we lost the war. Now it's time to go home and protect our families. These are bad times!"
+                message=_ "...It doesn’t matter who killed Garard, we don’t care what’s going on in the palace. We did our duty, we defended the crown as best we could, no matter that we lost the war. Now it’s time to go home and protect our families. These are bad times!"
             [/message]
 
             [message]
@@ -633,17 +633,18 @@
 
             [message]
                 speaker=desertir3
-                message=_ "What about the Crown? The Crown wants to rule the orcs now, there's a lot of them, and I see they're coming with you! Why fight for such a Crown?"
+                message=_ "What about the Crown? The Crown wants to rule the orcs now, there’s a lot of them, and I see they’re coming with you! Why fight for such a Crown?"
             [/message]
 
             [message]
                 speaker=Isolde
-                message=_ "Do you want your sons to fight the rebels instead of orcs? To have the royal army take young, gutless boys like de Ferres' henchmen do?"
+                message=_ "Do you want your sons to fight the rebels instead of orcs? To have the royal army take young, gutless boys like de Ferres’ henchmen do?"
             [/message]
 
             [message]
                 speaker=desertir2
-                message=_ "It's true, when I was in the village, I could hardly hide my boy from Sir Gwido's recruiters! They wanted to make him an archer, but he's no archer, he can't even pull a bowstring. No, we'd better stand up for our children and end this rebellion sooner!"
+                message=_ "...It doesn’t matter who killed Garard, we don’t care what’s going on in the palace. We did our duty, we defended the crown as best we could, no matter that we lost the war. Now its time to go home and protect our families. These are bad times!"
+                message=_ "It’s true, when I was in the village, I could hardly hide my boy from Sir Gwido’s recruiters! They wanted to make him an archer, but he’s no archer, he can’t even pull a bowstring. No, wed better stand up for our children and end this rebellion sooner!"
             [/message]
 
             [modify_unit]
@@ -682,7 +683,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "Sir Elec is deposed and killed, and you will share his fate if you do not recognize the queen's authority!"
+            message=_ "Sir Elec is deposed and killed, and you will share his fate if you do not recognize the queen’s authority!"
         [/message]
 
         [message]
@@ -726,7 +727,7 @@
                 [message]
                     scroll=no
                     speaker=unit
-                    message=_ "I'm unfaithful to my wife and even more so to that wicked orc-loving witch!"
+                    message=_ "I’m unfaithful to my wife and even more so to that wicked orc-loving witch!"
                 [/message]
             [/case]
             [case]
@@ -735,7 +736,7 @@
                 [message]
                     scroll=no
                     speaker=unit
-                    message=_ "I'm unfaithful to my husband and even more so to that wicked orc-loving witch!"
+                    message=_ "I’m unfaithful to my husband and even more so to that wicked orc-loving witch!"
                 [/message]
             [/case]
         [/switch]
@@ -757,7 +758,7 @@
         [message]
             scroll=no
             speaker=Isolde 
-            message=_ "If you value your life, rebel, tell me, how was it you joined forces with the elves of Glyn's Forest?"
+            message=_ "If you value your life, rebel, tell me, how was it you joined forces with the elves of Glyn’s Forest?"
         [/message]
 
         [message]
@@ -769,7 +770,7 @@
         [message]
             scroll=no
             speaker=Bazur
-            message=_ "You don't know how to interrogate. Watch how I do it!"
+            message=_ "You don’t know how to interrogate. Watch how I do it!"
         [/message]
 
         [sound]
@@ -793,7 +794,7 @@
         [message]
             scroll=no
             speaker=Bazur
-            message=_ "It's not my fault you humans are so fragile! That method always worked on orcs."
+            message=_ "It’s not my fault you humans are so fragile! That method always worked on orcs."
         [/message]
     [/event]
 
@@ -838,7 +839,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "Thank you. Tell the general the elves of Glyn's Forest are conspiring with the rebels."
+            message=_ "Thank you. Tell the general the elves of Glyn’s Forest are conspiring with the rebels."
         [/message]
 
         [message]
@@ -859,12 +860,12 @@
 
         [message]
             speaker=Isolde
-            message=_ "The General wants us to go straight to Tath and reinforce the orcish mercenaries besieging it, then await his arrival there. Taking such a direct route leaves Glyn's Forest on our flank... I never imagined elves dwelt there, or likewise that they'd throw in with the rebels. We should scour the outskirts of the forest and discover who this <i>Lady</i> is. Hopefully such a detour won't be construed as a refusal of orders."
+            message=_ "The General wants us to go straight to Tath and reinforce the orcish mercenaries besieging it, then await his arrival there. Taking such a direct route leaves Glyn’s Forest on our flank... I never imagined elves dwelt there, or likewise that they’d throw in with the rebels. We should scour the outskirts of the forest and discover who this <i>Lady</i> is. Hopefully such a detour won’t be construed as a refusal of orders."
         [/message]
 
         [message]
             speaker=Bazur
-            message=_ "Orders are orders, but it's always good to beat up tree-lovers!"
+            message=_ "Orders are orders, but it’s always good to beat up tree-lovers!"
         [/message]
 
         [message]
@@ -909,13 +910,13 @@
 
         [message]
             speaker=unit
-            message=_ "You hirelings of Asheviere shalln't have long to rejoice over my death! You'll all be slaughtered... at Tath's..."
+            message=_ "You hirelings of Asheviere shalln’t have long to rejoice over my death! You’ll all be slaughtered... at Tath’s..."
         [/message]
 
         [message]
             scroll=no
             speaker=Bazur
-            message=_ "Slaughtered! I'll slaughter your head, you worm!"
+            message=_ "Slaughtered! I’ll slaughter your head, you worm!"
         [/message]
     [/event]
 
@@ -930,7 +931,7 @@
         [message]
             scroll=no
             speaker=Isolde
-            message=_ "He spoke as though they have a trap awaiting us. I don't like it. But at least the fort is ours and we're one step closer to our goal."
+            message=_ "He spoke as though they have a trap awaiting us. I don’t like it. But at least the fort is ours and we’re one step closer to our goal."
         [/message]
     [/event]
 
@@ -939,7 +940,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "We've been here for days and yet victory eludes us still. Asheviere will have our heads!"
+            message=_ "We’ve been here for days and yet victory eludes us still. Asheviere will have our heads!"
         [/message]
 
         [message]
@@ -1056,7 +1057,7 @@
         [message]
             scroll=no
             speaker=Bazur
-            message=_ "Hey, the infantry commander had great armour! We can't leave such great plunder behind, someone has to take it."
+            message=_ "Hey, the infantry commander had great armour! We can’t leave such great plunder behind, someone has to take it."
         [/message]
 
         {HIGHLIGHT_IMAGE $armorX $armorY items/armor.png ()}
@@ -1078,7 +1079,7 @@
                 speaker=unit
                 message= _ "This armour will protect me from pierce (+20%), blade (+30%) and impact (+10%) damage, but will slow my movement (-1 max moves)."
                 [option]
-                    label= _ "I'll wear it."
+                    label= _ "I’ll wear it."
 
                     [command]
 
@@ -1092,7 +1093,7 @@
                     {CLEAR_VARIABLE armorY}
                     
                         [object]
-                            name=_"Iron Mauler's Armour"
+                            name=_"Iron Mauler’s Armour"
                             image=icons/steel_armor.png
                             description= _ "Forged from excellent Wesnoth steel, the armour of the Iron Mauler is a coveted trophy for any warrior, even though it is heavy."
                             duration=forever
@@ -1143,10 +1144,10 @@
             [message]
                 scroll=no
                 speaker=Bazur
-                message=_ "Hey, the infantry commander had great armour! We can't leave such great plunder behind, I'll take it."
+                message=_ "Hey, the infantry commander had great armour! We can’t leave such great plunder behind, I’ll take it."
             [/message]
             [object]
-                name=_"Iron Mauler's Armour"
+                name=_"Iron Mauler’s Armour"
                 image=icons/steel_armor.png
                 description= _ "Forged from excellent Wesnoth steel, the armour of the Iron Mauler is a coveted trophy for any warrior, even though it is heavy. (+30% blade, +20% pierce, +10% impact resistances, -1 movement)"
                 duration=forever
@@ -1194,7 +1195,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "If the Queen cared so much for these villagers, she should've given you more riders to collect war taxes from them. My warriors fight for gold. If the sight of a little looting turns your stomach then take the villages yourself and pay us our cut."
+            message=_ "If the Queen cared so much for these villagers, she should’ve given you more riders to collect war taxes from them. My warriors fight for gold. If the sight of a little looting turns your stomach then take the villages yourself and pay us our cut."
         [/message]
 
         [message]
@@ -1204,7 +1205,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "And I could slit your throat and blame it on the rebels, but have I? Let's not hinder each other when our goal is the same!"
+            message=_ "And I could slit your throat and blame it on the rebels, but have I? Let’s not hinder each other when our goal is the same!"
         [/message]
 
         [message]
@@ -1243,7 +1244,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "The rebel de Ferres's armored men are marching through this land, our mission is to defeat them. Perhaps Sir Knight can help us?"
+            message=_ "The rebel de Ferres’s armored men are marching through this land, our mission is to defeat them. Perhaps Sir Knight can help us?"
         [/message]
 
         [message]
@@ -1263,11 +1264,11 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Because otherwise, it might appear a band of orc mercenaries defeated de Ferres' army in clan lands while the clan knights stood idly by!"
+                message= _ "Because otherwise, it might appear a band of orc mercenaries defeated de Ferres’ army in clan lands while the clan knights stood idly by!"
                 [command]
                     [message]
                         speaker=Neutral_Knight 
-                        message=_ "For a knight to cede his valor to orcs is unthinkable! Very well, show me where de Ferres' men are, and I will crush them before your orcs can so much as draw their blades!"
+                        message=_ "For a knight to cede his valor to orcs is unthinkable! Very well, show me where de Ferres’ men are, and I will crush them before your orcs can so much as draw their blades!"
                     [/message]
 
                     [modify_side]
@@ -1290,7 +1291,7 @@
                 [command]
                     [message]
                         speaker=Neutral_Knight 
-                        message=_ "How dare you accuse me of cowardice?! I fear no one! I will defeat de Ferres' men, but first I will punish you for your filthy tongue!"
+                        message=_ "How dare you accuse me of cowardice?! I fear no one! I will defeat de Ferres’ men, but first I will punish you for your filthy tongue!"
                     [/message]
 
                     [modify_side]
@@ -1358,7 +1359,7 @@
         [message]
             scroll=no
             speaker=Bazur
-            message=_ "Good thing we didn't tear his pretty coat! It'll fit me or one of my cutthroats."
+            message=_ "Good thing we didn’t tear his pretty coat! It’ll fit me or one of my cutthroats."
         [/message]
 
         {HIGHLIGHT_IMAGE $x1 $y1 "items/cloak-green.png" ()}
@@ -1376,9 +1377,9 @@
             [/filter]
             [message]
                 speaker=unit
-                message= _ "This cloak looks bold and powerful, and would inspire me to take risks! If I pick it up, I'll gain the <i>charge</i> special on my melee attacks."
+                message= _ "This cloak looks bold and powerful, and would inspire me to take risks! If I pick it up, I’ll gain the <i>charge</i> special on my melee attacks."
                 [option]
-                    label= _ "I'll take it."
+                    label= _ "I’ll take it."
                     [command]
                         {REMOVE_IMAGE $knight_cloakX $knight_cloakY}
                         [remove_event]
@@ -1411,7 +1412,7 @@
                     [/command]
                 [/option]
                 [option]
-                    label= _ "I'll leave this for someone else."
+                    label= _ "I’ll leave this for someone else."
                     [command]
                         [allow_undo] 
                         [/allow_undo]
@@ -1441,12 +1442,12 @@
 
         [message]
             race=elf 
-            message=_ "Halt! The Lady has forbidden Asheviere's men to enter the forest."
+            message=_ "Halt! The Lady has forbidden Asheviere’s men to enter the forest."
         [/message]
 
         [message]
             speaker=Bazur 
-            message=_ "What about Asheviere's orcs?"
+            message=_ "What about Asheviere’s orcs?"
         [/message]
 
         [message]

--- a/scenarios/03_The_Iron_Hunt.cfg
+++ b/scenarios/03_The_Iron_Hunt.cfg
@@ -643,7 +643,6 @@
 
             [message]
                 speaker=desertir2
-                message=_ "...It doesn’t matter who killed Garard, we don’t care what’s going on in the palace. We did our duty, we defended the crown as best we could, no matter that we lost the war. Now its time to go home and protect our families. These are bad times!"
                 message=_ "It’s true, when I was in the village, I could hardly hide my boy from Sir Gwido’s recruiters! They wanted to make him an archer, but he’s no archer, he can’t even pull a bowstring. No, wed better stand up for our children and end this rebellion sooner!"
             [/message]
 

--- a/scenarios/04_A_Prophecy_in_the_Royal_Forest.cfg
+++ b/scenarios/04_A_Prophecy_in_the_Royal_Forest.cfg
@@ -106,12 +106,12 @@
 
             [message]
                 speaker=Isolde 
-                message=_ "It's a magic quintain, just like at the Royal Military Academy. The witch must have created it to train the peasants."
+                message=_ "It’s a magic quintain, just like at the Royal Military Academy. The witch must have created it to train the peasants."
             [/message]
 
             [message]
                 speaker=unit 
-                message=_ "I don't need training, but I'm gonna blow the quintain to smithereens!"
+                message=_ "I don’t need training, but I’m gonna blow the quintain to smithereens!"
             [/message]
         [/then])}
 
@@ -120,12 +120,12 @@
         [then]
             [message]
                 speaker=unit 
-                message=_ "Ouch, it's a magic quintain, the witch must have created it to train the peasants!"
+                message=_ "Ouch, it’s a magic quintain, the witch must have created it to train the peasants!"
             [/message]
 
             [message]
                 speaker=Isolde 
-                message=_ "I hear they have quintains like this at the Royal Military Academy. Let's see if I can pass this exam!"
+                message=_ "I hear they have quintains like this at the Royal Military Academy. Let’s see if I can pass this exam!"
             [/message]
         [/then])}
     [/event]
@@ -297,7 +297,7 @@
         no_leader=yes
         color=white
         team_name=bazur
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT ragged}
         save_id=bazur 
         [unit]
@@ -554,17 +554,17 @@
 
         [message]
             speaker=Martin 
-            message=_ "Old Delvick, is that you? How was the raid? Did you help de Ferres' men?"
+            message=_ "Old Delvick, is that you? How was the raid? Did you help de Ferres’ men?"
         [/message]
 
         [message]
             speaker=Isolde 
-            message=_ "De Ferres' men are in the ground and so is your Old Delvic! You will be joining them if you don't surrender to the Royal Army!"
+            message=_ "De Ferres’ men are in the ground and so is your Old Delvic! You will be joining them if you don’t surrender to the Royal Army!"
         [/message]
 
         [message]
             speaker=Martin 
-            message=_ "No way! You're gonna pay for this, orc-lovers!"
+            message=_ "No way! You’re gonna pay for this, orc-lovers!"
         [/message]
 
         [objectives]
@@ -607,12 +607,12 @@
 
         [message]
             speaker=Martin 
-            message=_ "No, don't, please! I surrender, I'll tell you everything, just don't feed me to the orcs!"
+            message=_ "No, don’t, please! I surrender, I’ll tell you everything, just don’t feed me to the orcs!"
         [/message]
 
         [message]
             speaker=Bazur 
-            message=_ "You're too rotten for eating! Die!"
+            message=_ "You’re too rotten for eating! Die!"
         [/message]
 
         [message]
@@ -627,7 +627,7 @@
 
         [message]
             speaker=Martin 
-            message=_ "I'll tell you, I'll tell you, if only the orc would step away! We are Sir Gwido's peasants. Our lord is friends with an elven witch, though she doesn't like to be called that. The lord convinced the witch to shelter us in this forest. Old Delvik was our elder and he was always meeting in secret with the lord and the witch. Northwest of here is our camp and it's full of men, all of them commoners like me. We were preparing to fight the queen, even my simple peasant arse! I knew I shouldn't be involved in this! Please forgive me!"
+            message=_ "I’ll tell you, I’ll tell you, if only the orc would step away! We are Sir Gwido’s peasants. Our lord is friends with an elven witch, though she doesn’t like to be called that. The lord convinced the witch to shelter us in this forest. Old Delvik was our elder and he was always meeting in secret with the lord and the witch. Northwest of here is our camp and it’s full of men, all of them commoners like me. We were preparing to fight the queen, even my simple peasant arse! I knew I shouldn’t be involved in this! Please forgive me!"
         [/message]
 
         [message]
@@ -642,7 +642,7 @@
 
         [message]
             speaker=Isolde 
-            message=_ "They're mercenaries. The queen uses them to keep people like you from being recruited."
+            message=_ "They’re mercenaries. The queen uses them to keep people like you from being recruited."
         [/message]
 
         [message]
@@ -652,7 +652,7 @@
 
         [message]
             speaker=Isolde 
-            message=_ "I'll grant you a pardon for your honesty. Begone from this forest and provide the rebels no further aid. Or the next time I catch you, there will be no mercy!"
+            message=_ "I’ll grant you a pardon for your honesty. Begone from this forest and provide the rebels no further aid. Or the next time I catch you, there will be no mercy!"
         [/message]
 
         [message]
@@ -857,7 +857,7 @@
 
         [message]
             speaker=Isolde 
-            message=_ "He wasn't lying, this camp is big enough to support a whole battalion! A hundred, no, two hundred rebels! And all these crates must be filled with their supplies and weapons."
+            message=_ "He wasn’t lying, this camp is big enough to support a whole battalion! A hundred, no, two hundred rebels! And all these crates must be filled with their supplies and weapons."
         [/message]
 
         [message]
@@ -867,12 +867,12 @@
 
         [message]
             speaker=Isolde 
-            message=_ "We can't leave such a horde in the rear, so, yes, let's attack, Bazur! We must strike before they can rally their full host!"
+            message=_ "We can’t leave such a horde in the rear, so, yes, let’s attack, Bazur! We must strike before they can rally their full host!"
         [/message]
 
         [message]
             speaker=Bazur 
-            message=_ "Oh, that I can do! Let's go!"
+            message=_ "Oh, that I can do! Let’s go!"
         [/message]
 
         [message]
@@ -968,7 +968,7 @@
                     description=_ "To burn a storage crate, bring any unit with a fire attack to a hex adjacent to it."
                 [/note]
                 [note]
-                    description=_ "Burning the storage will take 10 gold from each bandit's side."
+                    description=_ "Burning the storage will take 10 gold from each bandit’s side."
                 [/note]
                 [gold_carryover]
                     bonus=yes
@@ -1022,7 +1022,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "There's the witch!"
+            message=_ "There’s the witch!"
         [/message]
 
         [message]
@@ -1032,12 +1032,12 @@
 
         [message]
             speaker=Lady_Aviel 
-            message=_ "I am Lady Avielle, ancient keeper of the forest that humans have recently come to call Glyn's."
+            message=_ "I am Lady Avielle, ancient keeper of the forest that humans have recently come to call Glyn’s."
         [/message]
 
         [message]
             speaker=Isolde
-            message=_ "But Glyn's Forest belongs to the royal family."
+            message=_ "But Glyn’s Forest belongs to the royal family."
         [/message]
 
         [message]
@@ -1047,12 +1047,12 @@
 
         [message]
             speaker=Isolde
-            message=_ "How does protecting this forest inolve sheltering these bandits within it? Why did you even get involved with them? Elves like you shouldn't be prying into human matters."
+            message=_ "How does protecting this forest inolve sheltering these bandits within it? Why did you even get involved with them? Elves like you shouldn’t be prying into human matters."
         [/message]
 
         [message]
             speaker=Lady_Aviel 
-            message=_ "You are right, it was a rare event in the history of Wesnoth that caught my attention. Yet I have decided to intervene, for with Asheviere's reign, the history of Wesnoth has moved toward its sunset, and I am not comfortable with what is to come after the dissolution of your kingdom."
+            message=_ "You are right, it was a rare event in the history of Wesnoth that caught my attention. Yet I have decided to intervene, for with Asheviere’s reign, the history of Wesnoth has moved toward its sunset, and I am not comfortable with what is to come after the dissolution of your kingdom."
         [/message]
 
         [message]
@@ -1072,7 +1072,7 @@
 
         [message]
             speaker=Lady_Aviel 
-            message=_ "...Asheviere's fate is intertwined with chaos, war, and desolation. What she has done pales in comparison to the end of her reign, should she not be stopped. My child, I have seen the ashes of your cities, the wastelands of your fields, I have seen the fall of the human race, and the orcs feasting on the ruins of Wesnoth!"
+            message=_ "...Asheviere’s fate is intertwined with chaos, war, and desolation. What she has done pales in comparison to the end of her reign, should she not be stopped. My child, I have seen the ashes of your cities, the wastelands of your fields, I have seen the fall of the human race, and the orcs feasting on the ruins of Wesnoth!"
         [/message]
 
         [message]
@@ -1196,7 +1196,7 @@
                     side=1
                 [/enemy_of]
             [/filter_side]
-            message=_ "No problem Lars, there's only a band of orcs here, we can handle them!"
+            message=_ "No problem Lars, there’s only a band of orcs here, we can handle them!"
         [/message]
 
         {CLEAR_VARIABLE timer}
@@ -1222,18 +1222,18 @@
 
             [message]
                 speaker=Isolde
-                message=_ "We've been discovered before we'd even taken the outpost! This forest will be our graveyard!"
+                message=_ "We’ve been discovered before we’d even taken the outpost! This forest will be our graveyard!"
             [/message]
         [/then]
         [else]
             [message]
                 speaker=Isolde
-                message=_ "It was a bad idea to go into these woods. The plan was for us to join the siege of Tath, and we're still stuck here, unable to deal with the rebels! Asheviere will be furious."
+                message=_ "It was a bad idea to go into these woods. The plan was for us to join the siege of Tath, and we’re still stuck here, unable to deal with the rebels! Asheviere will be furious."
             [/message]
 
             [message]
                 speaker=Bazur
-                message=_ "Argh, that means she won't pay us!"
+                message=_ "Argh, that means she won’t pay us!"
             [/message]
         [/else]
         [/if]
@@ -1321,7 +1321,7 @@
                 [message]
                     scroll=no
                     speaker=Isolde
-                    message=_ "Good job! Let's burn down their storages and get out of here!"
+                    message=_ "Good job! Let’s burn down their storages and get out of here!"
                 [/message]
             [/else]
             [/if]
@@ -1348,7 +1348,7 @@
 
         [message]
             speaker=Isolde 
-            message=_ "Let General Dommel's men deal with her, we need to go to Tath. By the looks of it, the orcs have already encircled the city."
+            message=_ "Let General Dommel’s men deal with her, we need to go to Tath. By the looks of it, the orcs have already encircled the city."
         [/message]
 
         [message]
@@ -1376,12 +1376,12 @@
 
         [message]
             speaker=Isolde
-            message=_ "I don't know, I just felt it was wrong to kill her."
+            message=_ "I don’t know, I just felt it was wrong to kill her."
         [/message]
 
         [message]
             speaker=Bazur 
-            message=_ "Oh, you don't get it! You can't spare tree-lovers, you have to cut them down, and then cut them smaller! They're almost immortal! They'll wait until you're old and decrepit and then they'll come for revenge!"
+            message=_ "Oh, you don’t get it! You can’t spare tree-lovers, you have to cut them down, and then cut them smaller! They’re almost immortal! They’ll wait until you’re old and decrepit and then they’ll come for revenge!"
         [/message]
 
         [message]
@@ -1480,7 +1480,7 @@
                     side=1
                 [/enemy_of]
             [/filter_side]
-            message=_ "You're right, let's stand up for Tath!"
+            message=_ "You’re right, let’s stand up for Tath!"
         [/message]
     [/event]
 [/scenario]

--- a/scenarios/05_Discipline.cfg
+++ b/scenarios/05_Discipline.cfg
@@ -61,7 +61,7 @@
         {BAZUR_ARC_I}
         color=white
         team_name=bazur
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         save_id=bazur
         {FLAG_VARIANT ragged}
     [/side]
@@ -78,7 +78,7 @@
         id=Warlord_South
         recruit=Orcish Grunt,Troll Whelp,Troll,Troll Rocklobber,Troll Warrior,Orcish Archer
         team_name=bazur,evil_orcs
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         color=blue
         {FLAG_VARIANT ragged}
         [ai]
@@ -112,7 +112,7 @@
         recruit=Orcish Archer,Orcish Crossbowman,Goblin Pillager,Goblin Knight,Wolf Rider,Orcish Grunt
         color=green
         team_name=bazur,evil_orcs
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT ragged}
         [ai]
             {NO_SCOUTS}
@@ -426,7 +426,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "Looks like the orcs have only begun their siege! We're just in time!"
+            message=_ "Looks like the orcs have only begun their siege! We’re just in time!"
         [/message] 
 
         [message]
@@ -452,7 +452,7 @@
         [message]
             scroll=no
             speaker=Isolde
-            message=_ "Got it. And what's a fox-tail?"
+            message=_ "Got it. And what’s a fox-tail?"
         [/message] 
 
         [scroll_to_unit]
@@ -462,12 +462,12 @@
         [message]
             speaker=Bazur
             scroll=no
-            message=_ "The fox-tails are the other orcs, under the green banner. They like fire, that's why they're called fox-tails, which in our tongue means 'fire'. They burn everything but they don't know how to fight. They are as useless as troll-heads, so they are not respected."
+            message=_ "The fox-tails are the other orcs, under the green banner. They like fire, that’s why they’re called fox-tails, which in our tongue means ‘fire’. They burn everything but they don’t know how to fight. They are as useless as troll-heads, so they are not respected."
         [/message] 
 
         [message]
             speaker=Isolde
-            message=_ "I see. And you're from a respected clan, I take it?"
+            message=_ "I see. And you’re from a respected clan, I take it?"
         [/message] 
 
         [message]
@@ -477,7 +477,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "I'll be proud when we take Tath. Go ahead, prove you're better than them!"
+            message=_ "I’ll be proud when we take Tath. Go ahead, prove you’re better than them!"
         [/message]
 
         [message]
@@ -487,7 +487,7 @@
 
         [message]
             speaker=Sir_Gwido 
-            message=_ "We're surrounded, but don't despair, friends! I've sent Lars to Glyn's Forest, he'll be back soon with reinforcements!"
+            message=_ "We’re surrounded, but don’t despair, friends! I’ve sent Lars to Glyn’s Forest, he’ll be back soon with reinforcements!"
         [/message]
 
         [scroll_to_unit]
@@ -523,7 +523,7 @@
                         [/variable]
                     [/show_if]
                     caption=_ "New task:"
-                    description= _ "Kill all enemies within a 5 hex radius of Tath's citadel"
+                    description= _ "Kill all enemies within a 5 hex radius of Tath’s citadel"
                     condition=win
                 [/objective]
                 [objective]
@@ -552,7 +552,7 @@
 
         [message]
             speaker=Sir_Gwido 
-            message=_ "Apparently, I'm destined to fall in this fight... Lady Aviel, I dedicate my last wish to you - may you be safe!"
+            message=_ "Apparently, I’m destined to fall in this fight... Lady Aviel, I dedicate my last wish to you - may you be safe!"
         [/message]
     [/event]
 
@@ -629,7 +629,7 @@
 
         [message]
             speaker=Warlord_South
-            message=_ "We have orders to deal with the rebels and we're just getting started, why stop?"
+            message=_ "We have orders to deal with the rebels and we’re just getting started, why stop?"
         [/message] 
 
         [message]
@@ -644,7 +644,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "What's wrong with punishing and plundering the rebels?"
+            message=_ "What’s wrong with punishing and plundering the rebels?"
         [/message]
 
         [message]
@@ -654,7 +654,7 @@
 
         [message]
             speaker=Warlord_West
-            message=_ "'Oh, the queen, our mighty queen!' Hahaha! Your queen can't do anything without orcs! Why do you listen to that human, Whitefang? Kill her and join the fun!"
+            message=_ "‘Oh, the queen, our mighty queen!’ Hahaha! Your queen can’t do anything without orcs! Why do you listen to that human, Whitefang? Kill her and join the fun!"
         [/message] 
 
         [message]
@@ -675,7 +675,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "She's got a point. It's better to obey the queen, she'll pay more that way!"
+            message=_ "She’s got a point. It’s better to obey the queen, she’ll pay more that way!"
         [/message]
 
         [if]
@@ -689,7 +689,7 @@
         [then]
             [message]
                 speaker=Warlord_West
-                message=_ "What a shame, the Whitefang chief is scared of a she-human! I'm not like him, I'll take what's mine and no one will stop me!"
+                message=_ "What a shame, the Whitefang chief is scared of a she-human! I’m not like him, I’ll take what’s mine and no one will stop me!"
             [/message]
 
             [message]
@@ -699,7 +699,7 @@
 
             [message]
                 speaker=Isolde
-                message=_ "It's a good thing you're wiser than those two. General Dommel will be here soon, and if we don't drive these marauders out of the town, he'll punish us along with them!"
+                message=_ "It’s a good thing you’re wiser than those two. General Dommel will be here soon, and if we don’t drive these marauders out of the town, he’ll punish us along with them!"
             [/message] 
 
             [message]
@@ -879,7 +879,7 @@
 
         [message]
             speaker=Dommel
-            message=_ "Silence, orc, I'm not talking to you!"
+            message=_ "Silence, orc, I’m not talking to you!"
         [/message] 
 
         [message]
@@ -971,7 +971,7 @@
 
             [message]
                 speaker=Dommel
-                message=_ "Mark my words, orc! You have been recruited into the <i>Royal Army</i>. What separates the <i>Royal Army</i> from the orcish horde is <i>iron discipline</i>. <i>Discipline</i> means obeying orders <i>exactly</i> as commanded. You kill only those you're ordered to kill. If you disobey orders, you'll share the fate of these marauders. Do I make myself clear?"
+                message=_ "Mark my words, orc! You have been recruited into the <i>Royal Army</i>. What separates the <i>Royal Army</i> from the orcish horde is <i>iron discipline</i>. <i>Discipline</i> means obeying orders <i>exactly</i> as commanded. You kill only those you’re ordered to kill. If you disobey orders, you’ll share the fate of these marauders. Do I make myself clear?"
             [/message] 
 
             [message]
@@ -986,7 +986,7 @@
 
             [message]
                 speaker=Dommel
-                message=_ "I got your dispatch, Isolde. Tell me of the happenings in Glyn's Forest."
+                message=_ "I got your dispatch, Isolde. Tell me of the happenings in Glyn’s Forest."
             [/message]
 
             [message]
@@ -997,7 +997,7 @@
 
             [message]
                 speaker=Dommel
-                message=_ "So the witch did ruin Gwido after all. That's unfortunate. Did you kill her?"
+                message=_ "So the witch did ruin Gwido after all. That’s unfortunate. Did you kill her?"
             [/message]
 
             [message]
@@ -1007,7 +1007,7 @@
 
             [message]
                 speaker=Dommel
-                message=_ "And rightly so. All the elvish lords have their eyes on our war right now. We cannot give them a reason to interfere. Although I don't think elves belong in a forest named after the Founding King's son."
+                message=_ "And rightly so. All the elvish lords have their eyes on our war right now. We cannot give them a reason to interfere. Although I don’t think elves belong in a forest named after the Founding King’s son."
             [/message]
 
             [message]
@@ -1017,12 +1017,12 @@
 
             [message]
                 speaker=Dommel
-                message=_ "The queen defeated de Ferres at Weldyn and has moved on to Dan'Tonk. I have orders to lay siege to the city from the north. I also have special orders for orcs loyal to the crown, if there are any such things."
+                message=_ "The queen defeated de Ferres at Weldyn and has moved on to Dan’Tonk. I have orders to lay siege to the city from the north. I also have special orders for orcs loyal to the crown, if there are any such things."
             [/message] 
 
             [message]
                 speaker=Bazur
-                message=_ "I'm loyal to the crown, loyal as can be!"
+                message=_ "I’m loyal to the crown, loyal as can be!"
             [/message] 
 
             [message]
@@ -1032,7 +1032,7 @@
 
             [message]
                 speaker=Dommel
-                message=_ "Dan'Tonk is a great fortress. Even after all his defeats, de Ferres has hundreds of soldiers at hand. A straight assault would cost us dearly. However, there is a secret tunnel between Tath and Dan'Tonk that leads to the catacombs, and from there to the heart of the city. The queen wants the orcs to sneak through the tunnel and open the gates of Dan'Tonk from the inside just before the assault."
+                message=_ "Dan’Tonk is a great fortress. Even after all his defeats, de Ferres has hundreds of soldiers at hand. A straight assault would cost us dearly. However, there is a secret tunnel between Tath and Dan’Tonk that leads to the catacombs, and from there to the heart of the city. The queen wants the orcs to sneak through the tunnel and open the gates of Dan’Tonk from the inside just before the assault."
             [/message] 
 
             [message]
@@ -1047,7 +1047,7 @@
 
             [message]
                 speaker=Dommel
-                message=_ "You mustn't go with the orcs, Isolde. Stay in my army, I'll give you a squad of swordsmen instead of these brutes."
+                message=_ "You mustn’t go with the orcs, Isolde. Stay in my army, I’ll give you a squad of swordsmen instead of these brutes."
             [/message]
 
             [message]
@@ -1057,17 +1057,17 @@
 
             [message]
                 speaker=Dommel
-                message=_ "You sound just like your husband. That's why I don't wish to send you. There's little chance of survival in the middle of a siege and Wesnoth needs people like you."
+                message=_ "You sound just like your husband. That’s why I don’t wish to send you. There’s little chance of survival in the middle of a siege and Wesnoth needs people like you."
             [/message]
 
             [message]
                 speaker=Isolde
-                message=_ "I would disgrace my husband's honor if I abandoned my soldiers."
+                message=_ "I would disgrace my husband’s honor if I abandoned my soldiers."
             [/message] 
 
             [message]
                 speaker=Dommel
-                message=_ "Then I won't discourage you. Go, and may all the gods protect you, if they still care about our country."
+                message=_ "Then I won’t discourage you. Go, and may all the gods protect you, if they still care about our country."
             [/message]
 
             [message]
@@ -1088,7 +1088,7 @@
                 duration=forever 
                 name= _ "Wesnothian Great Sword"
                 image="attacks/greatsword-human.png"
-                description= _ "The honed blade from the Royal Armory replaces Bazur's sword, and increases melee damage by 3!"
+                description= _ "The honed blade from the Royal Armory replaces Bazur’s sword, and increases melee damage by 3!"
 
                 [effect]
                     apply_to=attack 
@@ -1101,12 +1101,12 @@
 
             [message]
                 speaker=Bazur
-                message=_ "So big and sharp! I'm proud, I'm so proud!"
+                message=_ "So big and sharp! I’m proud, I’m so proud!"
             [/message]
 
             [message]
                 speaker=Dommel
-                message=_ "Now go. The assault will begin in two weeks, you'll know it by the terrible rumble from the surface. As soon as the rumbling dies down some, go in. And try to survive, Isolde."
+                message=_ "Now go. The assault will begin in two weeks, you’ll know it by the terrible rumble from the surface. As soon as the rumbling dies down some, go in. And try to survive, Isolde."
             [/message]
 
             [message]
@@ -1148,7 +1148,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "We did not take Tath in time... the Queen's plan is foiled. General Dommel will be here soon and he will be furious."
+            message=_ "We did not take Tath in time... the Queen’s plan is foiled. General Dommel will be here soon and he will be furious."
         [/message]
 
         [message]
@@ -1233,7 +1233,7 @@
 
         [message]
             speaker=second_unit
-            message=_ "A-a-a, it's not ours, royal punishers are coming out of the woods!"
+            message=_ "A-a-a, it’s not ours, royal punishers are coming out of the woods!"
         [/message]
 
         [message]
@@ -1262,7 +1262,7 @@
 
         [message]
             speaker=unit
-            message=_ "You have failed the Lady and won't fight for your freedom. You are not worthy of the elves' help, death is the best outcome for you!"
+            message=_ "You have failed the Lady and won’t fight for your freedom. You are not worthy of the elves’ help, death is the best outcome for you!"
         [/message]
     [/event]
 
@@ -1317,7 +1317,7 @@
 
         [message]
             speaker=Big_Kruuk
-            message=_ "Didn't run away! Ha-ha-ha!"
+            message=_ "Didn’t run away! Ha-ha-ha!"
         [/message] 
     [/event]
 
@@ -1349,7 +1349,7 @@
         [else]
             [message]
                 speaker=Vengeful_Elf 
-                message=_ "I am the instrument of Lady Aviel's retribution. Prepare to die, villains!"
+                message=_ "I am the instrument of Lady Aviel’s retribution. Prepare to die, villains!"
             [/message]
             [message]
                 speaker=Bazur
@@ -1369,7 +1369,7 @@
         [then]
             [message]
                 speaker=Bazur
-                message=_ "I told you we should kill her! Now you'll have assassins like this chasing you for the rest of your days."
+                message=_ "I told you we should kill her! Now you’ll have assassins like this chasing you for the rest of your days."
             [/message]
 
             [message]
@@ -1418,12 +1418,12 @@
 
             [message]
                 speaker=Punk
-                message=_ "We heard a she-human is desperate for hirelings, and she pays well! Some horseriders told us to go to Soradoc and she'd hire us. But where is Soradoc? We went to some town in the south and we were met with arrows! Punk thinks horseriders told lies."
+                message=_ "We heard a she-human is desperate for hirelings, and she pays well! Some horseriders told us to go to Soradoc and she’d hire us. But where is Soradoc? We went to some town in the south and we were met with arrows! Punk thinks horseriders told lies."
             [/message]
 
             [message]
                 speaker=Bazur
-                message=_ "You're wrong, 'tis all true. I myself am a hireling for their Queen Majesty!"
+                message=_ "You’re wrong, ’tis all true. I myself am a hireling for their Queen Majesty!"
             [/message]
 
             [message]
@@ -1434,11 +1434,11 @@
             [message]
                 speaker=Bazur
                 [option]
-                    message= _ "Good enough to make me the next High Chief! Join me and you'll get some too!"
+                    message= _ "Good enough to make me the next High Chief! Join me and you’ll get some too!"
                     [command]
                         [message]
                             speaker=Punk
-                            message=_ "Punk's no fool, he won't fight for nothing. Give 100 gold coins and Punk is yours!"
+                            message=_ "Punk’s no fool, he won’t fight for nothing. Give 100 gold coins and Punk is yours!"
                         [/message]
 
                         [store_gold]
@@ -1452,7 +1452,7 @@
                                 [show_if]
                                     {VARIABLE_CONDITIONAL bazurgold greater_than_equal_to 100}
                                 [/show_if]
-                                message=_ "Alright, here's your gold, now get to work! (-100 gold)"
+                                message=_ "Alright, here’s your gold, now get to work! (-100 gold)"
                                 [command]
 
                                     [sound]
@@ -1481,7 +1481,7 @@
                                 [show_if]
                                     {VARIABLE_CONDITIONAL bazurgold less_than 100}
                                 [/show_if]
-                                message=_ "I don't have 100 gold right now."
+                                message=_ "I don’t have 100 gold right now."
                                 [command]
                                     [message]
                                         speaker=Punk 
@@ -1509,7 +1509,7 @@
                     [/command]
                 [/option]
                 [option]
-                    message= _ "Sure is! But you won't see any of it, you runt! Begone, I'll have no competitors!"
+                    message= _ "Sure is! But you won’t see any of it, you runt! Begone, I’ll have no competitors!"
                     [command]
                         [message]
                             speaker=Punk 
@@ -1589,13 +1589,13 @@
 
         [message]
             speaker=Sir_Gwido
-            message=_ "Good to see you riders! We're in a tough spot, see if you can't break through this orc encirclement!"
+            message=_ "Good to see you riders! We’re in a tough spot, see if you can’t break through this orc encirclement!"
         [/message]
 
         [message]
             side=7 
             type=Cavalier 
-            message=_ "We'll cut our way through. "
+            message=_ "We’ll cut our way through. "
         [/message]
         [/then]
 
@@ -1623,7 +1623,7 @@
         [message]
             speaker=second_unit
             image_pos=right # because he'll often have the same portrait as Aryn
-            message=_ "A regret to see a worthy cavalryman in the enemy's ranks! A stroke of the sword will eliminate this sight!"
+            message=_ "A regret to see a worthy cavalryman in the enemy’s ranks! A stroke of the sword will eliminate this sight!"
         [/message]
 
         [message]
@@ -1654,9 +1654,9 @@
         {ADVANCE_UNIT id=Aryn ""}
 
         [object]
-            name=_"Cavalier's Crossbow"
+            name=_"Cavalier’s Crossbow"
             image="attacks/crossbow-human.png"
-            description= _ "With a second crossbow at his hip, Aryn's ranged attack is now twice as powerful!"
+            description= _ "With a second crossbow at his hip, Aryn’s ranged attack is now twice as powerful!"
             duration=forever
             [filter]
                 id=Aryn
@@ -1682,7 +1682,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "Hey, that runt's dropped a vial of the special poison they use on their wolves' claws! Somebody's got to pick it up!"
+            message=_ "Hey, that runt’s dropped a vial of the special poison they use on their wolves’ claws! Somebody’s got to pick it up!"
         [/message]
 
         {HIGHLIGHT_IMAGE $unit.x $unit.y items/potion-poison.png ()}
@@ -1703,7 +1703,7 @@
                 speaker=unit
                 message= _ "I can put poison on my melee weapons, and get the <i>poison</i> special for them."
                 [option]
-                    label= _ "I'll take it."
+                    label= _ "I’ll take it."
                     [command]
                         {REMOVE_IMAGE $poisonX $poisonY}
                         [remove_event]
@@ -1714,7 +1714,7 @@
                         {CLEAR_VARIABLE poisonY}
 
                         [object]
-                            name= _ "Goblin's Special Posion"
+                            name= _ "Goblin’s Special Posion"
                             image=icons/potion_green_small.png
                             description= _ "Brewed by goblin alchemists from the most toxic of materials, the poison will be a good asset to any fighter who does not hesitate to use such an insidious tool."
                             [effect]
@@ -1734,7 +1734,7 @@
                     [/command]
                 [/option]
                 [option]
-                    label= _ "I'll leave this for someone else."
+                    label= _ "I’ll leave this for someone else."
                     [command]
                         [allow_undo] 
                         [/allow_undo]

--- a/scenarios/06_The_Art_of_War.cfg
+++ b/scenarios/06_The_Art_of_War.cfg
@@ -14,13 +14,13 @@
         [/part]
 
         [part]
-            story=_ "Asheviere was well aware that she was calling down a storm. She had seen that orcish loyalty was measured only in gold; that chieftains moved against each other as often as the royal army, all the while pillaging the land and its people wherever they went. But the Queen needed soldiers who cared nothing for the ideals of Wesnoth’s rebels; soldiers happy to support any cause so long as they were paid. That it was the pillaged commoners who bore this burden was so much the better for the royal treasury. Thusly a great many villagers paid the price for the Queen's war machine, often with their very lives."
+            story=_ "Asheviere was well aware that she was calling down a storm. She had seen that orcish loyalty was measured only in gold; that chieftains moved against each other as often as the royal army, all the while pillaging the land and its people wherever they went. But the Queen needed soldiers who cared nothing for the ideals of Wesnoth’s rebels; soldiers happy to support any cause so long as they were paid. That it was the pillaged commoners who bore this burden was so much the better for the royal treasury. Thusly a great many villagers paid the price for the Queen’s war machine, often with their very lives."
             {AD_BIGMAP}
             {JOURNEY_05_OLD}
         [/part]
 
         [part]
-            story=_ "Shocked by Asheviere's willingness to unleash orcs upon the kingdom, the remaining eastern rebels, already scattered and disorganized, fell swiftly to the northern hordes. The western provinces — particularly Elensefar — had no desire to involve themselves in another war so soon after Garard’s, a view only encouraged by the imposing presence of Fortress Halstead, with its vast garrison and high walls rivaling those of even Dan'Tonk."
+            story=_ "Shocked by Asheviere’s willingness to unleash orcs upon the kingdom, the remaining eastern rebels, already scattered and disorganized, fell swiftly to the northern hordes. The western provinces — particularly Elensefar — had no desire to involve themselves in another war so soon after Garard’s, a view only encouraged by the imposing presence of Fortress Halstead, with its vast garrison and high walls rivaling those of even Dan’Tonk."
             {AD_BIGMAP}
             {JOURNEY_05_OLD}
         [/part]
@@ -68,7 +68,7 @@
         extra_recruit=Spearman,Bowman,Heavy Infantryman,Fencer,Swordsman,Pikeman,Longbowman,Cavalryman,Dragoon,Javelineer,Mage,Lieutenant
         color=red
         team_name=queen
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT loyalist} 
 
         [unit]
@@ -188,7 +188,7 @@
         color=red
         hidden=yes
         team_name=queen
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT loyalist}
     [/side]
 
@@ -355,7 +355,7 @@
             [message]
                 speaker=Ghuvog
                 #po: while Asheviere may have lofty ideals, at the end of the day she's not a wise ruler
-                message=_ "Graah, I know a warlord when I see one. What're youse all gonna do now, chase them down?"
+                message=_ "Graah, I know a warlord when I see one. What’re youse all gonna do now, chase them down?"
             [/message]
 
             [message]
@@ -365,7 +365,7 @@
 
             [message]
                 speaker=Ghuvog
-                message=_ "Ah, back in Garard's War, I remember a time we surrounded and slaughtered an entire squad of knights chasing our goblins. Good memories!"
+                message=_ "Ah, back in Garard’s War, I remember a time we surrounded and slaughtered an entire squad of knights chasing our goblins. Good memories!"
             [/message]
 
             [message]
@@ -414,7 +414,7 @@
 
         [message]
             speaker=Ghuvog
-            message=_ "Hahaha, time to beat some discipline into these rebels! What's the plan, Queen?"
+            message=_ "Hahaha, time to beat some discipline into these rebels! What’s the plan, Queen?"
         [/message]
 
         [message]
@@ -424,22 +424,22 @@
 
         [message]
             speaker=Ghuvog
-            message=_ "Assassins in the vanguard, followed by swordsmen and trolls, with archers in the back. We strike at sunset, and by dawn there'll be no one left to fight back!"
+            message=_ "Assassins in the vanguard, followed by swordsmen and trolls, with archers in the back. We strike at sunset, and by dawn there’ll be no one left to fight back!"
         [/message]
 
         [message]
             speaker=Asheviere
-            message=_ "Crude, primitive; no, that does not suit me. De Ferres' army is as strong as ours; we shall not fight them with brute force, piling up mountains of skulls. Even if we were to win, our ranks would be too thin to march on Dan'Tonk."
+            message=_ "Crude, primitive; no, that does not suit me. De Ferres’ army is as strong as ours; we shall not fight them with brute force, piling up mountains of skulls. Even if we were to win, our ranks would be too thin to march on Dan’Tonk."
         [/message]
 
         [message]
             speaker=Ghuvog
-            message=_ "Graah, why bother with Dan'Tonk? Kill 'em all here!"
+            message=_ "Graah, why bother with Dan’Tonk? Kill ’em all here!"
         [/message]
 
         [message]
             speaker=Asheviere
-            message=_ "I know my enemy well. As long as de Ferres holds the richest province in Wesnoth, he will always find a way to survive and return with a new army. The war will not end until Dan'Tonk bows to my will."
+            message=_ "I know my enemy well. As long as de Ferres holds the richest province in Wesnoth, he will always find a way to survive and return with a new army. The war will not end until Dan’Tonk bows to my will."
         [/message]
 
         [message]
@@ -449,7 +449,7 @@
 
         [message]
             speaker=Asheviere
-            message=_ "First, let us send a scout into the enemy camp. Knowledge is power; maybe learning the rebels' formation will help us choose the right tactics."
+            message=_ "First, let us send a scout into the enemy camp. Knowledge is power; maybe learning the rebels’ formation will help us choose the right tactics."
         [/message]
 
         [objectives]
@@ -516,7 +516,7 @@
 
             [message]
                 speaker=Asheviere 
-                message=_ "Give Sir Ellaent this sword and a message: if you are afraid to attack a woman's army, accept Garard's sword, perhaps it will strengthen your resolve."
+                message=_ "Give Sir Ellaent this sword and a message: if you are afraid to attack a woman’s army, accept Garard’s sword, perhaps it will strengthen your resolve."
             [/message]
 
             [message]
@@ -606,7 +606,7 @@
 
                 [message]
                     speaker=Baron_Richard
-                    message=_ "Ellaent, what are you doing?! It's not time to attack yet, you've ruined my plan!"
+                    message=_ "Ellaent, what are you doing?! It’s not time to attack yet, you’ve ruined my plan!"
                 [/message]
 
                 [message]
@@ -617,7 +617,7 @@
                 [message]
                     sound=horn-signals/horn-2.ogg
                     speaker=Baron_Richard
-                    message=_ "We'll have to support the knights or we'll be defeated in detail! Soldiers, forward!"
+                    message=_ "We’ll have to support the knights or we’ll be defeated in detail! Soldiers, forward!"
                 [/message]
 
                 [modify_ai]
@@ -644,7 +644,7 @@
                     [message]
                         sound=horn-signals/horn-3.ogg
                         speaker=Sir_Grey
-                        message=_ "I don't know what's happened, but the plan is for us to attack now. Come on, ironmen, let's crush the Asheviere's dogs!"
+                        message=_ "I don’t know what’s happened, but the plan is for us to attack now. Come on, ironmen, let’s crush the Asheviere’s dogs!"
                     [/message]
 
                     [modify_ai]
@@ -670,7 +670,7 @@
         [message]
             sound=horn-signals/horn-1.ogg
             speaker=Baron_Richard 
-            message=_ "The regiments are drawn up, the soldiers are ready. It's time to attack! Forward, lords, for Wesnoth!"
+            message=_ "The regiments are drawn up, the soldiers are ready. It’s time to attack! Forward, lords, for Wesnoth!"
         [/message]
 
         [message]
@@ -682,7 +682,7 @@
         [message]
             sound=horn-signals/horn-3.ogg
             speaker=Sir_Grey
-            message=_ "And my armored men will break her orcs' bones. Forward, soldiers, let us throw off the evil queen's yoke!"
+            message=_ "And my armored men will break her orcs’ bones. Forward, soldiers, let us throw off the evil queen’s yoke!"
         [/message]
 
         [message]
@@ -705,7 +705,7 @@
 
         [message]
             speaker=Ghuvog
-            message=_ "Don't worry, queen, we're not short on valor. And if anyone fails, I will bring discipline back with the sword."
+            message=_ "Don’t worry, queen, we’re not short on valor. And if anyone fails, I will bring discipline back with the sword."
         [/message]
 
         [message]
@@ -931,7 +931,7 @@
         [message]
             speaker=unit 
             sound=horn-signals/horn-3.ogg 
-            message=_ "No, I will not die at the hands of the queen's filthy henchman! I retreat, but mark my words, Asheviere, we will meet again, and that meeting will be your last!"
+            message=_ "No, I will not die at the hands of the queen’s filthy henchman! I retreat, but mark my words, Asheviere, we will meet again, and that meeting will be your last!"
         [/message]
 
         [message]
@@ -969,7 +969,7 @@
         [message]
             speaker=unit 
             sound=horn-signals/horn-4.ogg 
-            message=_ "Blast, our luck has turned against us. But I can't die here... men, fall back!"
+            message=_ "Blast, our luck has turned against us. But I can’t die here... men, fall back!"
         [/message]
 
         [message]
@@ -1013,7 +1013,7 @@
         [message]
             speaker=Asheviere
             scroll=no
-            message=_ "We shall see who hangs who from the gallows once my soldiers march through the streets of Dan'Tonk. Crawl back into your hole, Richard!"
+            message=_ "We shall see who hangs who from the gallows once my soldiers march through the streets of Dan’Tonk. Crawl back into your hole, Richard!"
         [/message]
 
         [kill]
@@ -1276,7 +1276,7 @@
 
         [message]
             speaker=Ghuvog
-            message=_ "I'll cut you to pieces!"
+            message=_ "I’ll cut you to pieces!"
         [/message]
     [/event]
 

--- a/scenarios/07_An_Underground_Feud.cfg
+++ b/scenarios/07_An_Underground_Feud.cfg
@@ -19,12 +19,12 @@
 
     [story]
         [part]
-            story=_ "With Queen Asheviere from the south and General Dommel from the north, Dan'Tonk was now surrounded. The soldiers of the crown were more driven than ever — emboldened by a hope that the fall of Dan'Tonk should bring the bloodshed of civil war to a close."
+            story=_ "With Queen Asheviere from the south and General Dommel from the north, Dan’Tonk was now surrounded. The soldiers of the crown were more driven than ever — emboldened by a hope that the fall of Dan’Tonk should bring the bloodshed of civil war to a close."
             {AD_BIGMAP}
             {JOURNEY_05_OLD}
         [/part]
         [part]
-            story=_ "But victory would not come easily. Dan'Tonk was a fortress nigh-unto Weldyn itself and still maintained a garrison of several thousand soldiers even after Baron de Ferres's defeats. Both Asheviere and the rebel lords would risk all in this final pitched battle."
+            story=_ "But victory would not come easily. Dan’Tonk was a fortress nigh-unto Weldyn itself and still maintained a garrison of several thousand soldiers even after Baron de Ferres’s defeats. Both Asheviere and the rebel lords would risk all in this final pitched battle."
             {AD_BIGMAP}
             {JOURNEY_05_OLD}
         [/part]
@@ -52,7 +52,7 @@
         {BAZUR_ARC_I}
         color=white
         team_name=bazur
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         save_id=bazur
         {FLAG_VARIANT ragged}
     [/side]
@@ -105,7 +105,7 @@
         name=_ "Chuchelka I"
         color=green
         team_name=chuchelka
-        user_team_name= _ "Chuchelka's Forces"
+        user_team_name= _ "Chuchelka’s Forces"
 
         [unit]
             type=Shadow Lord
@@ -148,7 +148,7 @@
         name=_ "False Chuchelka"
         color=purple
         team_name=rebel_chuchelka
-        user_team_name= _ "False Chuchelka's Forces"
+        user_team_name= _ "False Chuchelka’s Forces"
     [/side]
 
     {PEASANT_SIDE 5}
@@ -371,7 +371,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "... That Dommel of yours, he's so angry! But that's good; a leader must be angry."
+            message=_ "... That Dommel of yours, he’s so angry! But that’s good; a leader must be angry."
         [/message]
 
         [message]
@@ -381,7 +381,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "Words! Words are rubbish, but I'll never forget how he executed those chiefs!"
+            message=_ "Words! Words are rubbish, but I’ll never forget how he executed those chiefs!"
         [/message]
 
         [message]
@@ -396,7 +396,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "By my best guess, we're still a few days from Dan'Tonk. How I long to reach the surface... The underworld is so miserably cold and dark."
+            message=_ "By my best guess, we’re still a few days from Dan’Tonk. How I long to reach the surface... The underworld is so miserably cold and dark."
         [/message]
 
         [store_unit]
@@ -743,9 +743,9 @@
 
                         [message]
                             speaker=unit
-                            message= _ "This helmet will protect me from blade and pierce (+10%) damage. I'll be braver to rush into the battlefield with it on! (+1 move)."
+                            message= _ "This helmet will protect me from blade and pierce (+10%) damage. I’ll be braver to rush into the battlefield with it on! (+1 move)."
                             [option]
-                                label= _ "I'll take it."
+                                label= _ "I’ll take it."
                                 [command]
                                     {REMOVE_IMAGE $helmetX $helmetY}
                                     [remove_event]
@@ -761,7 +761,7 @@
                                     [object]
                                         name=_"Royal Helm"
                                         image="icons/helmet_frogmouth.png"
-                                        description= _ "Only lightly dented, this gilded helm once belonged to the captain of Dan'tonk's swordsmen."
+                                        description= _ "Only lightly dented, this gilded helm once belonged to the captain of Dan’tonk’s swordsmen."
                                         duration=forever
                                         [filter]
                                             find_in=unit
@@ -792,7 +792,7 @@
                                 [/command]
                             [/option]
                             [option]
-                                label= _ "I'll leave this for someone else."
+                                label= _ "I’ll leave this for someone else."
                                 [command]
                                     [allow_undo] 
                                     [/allow_undo]
@@ -973,7 +973,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "I'd like to survive the coming battle, you know."
+            message=_ "I’d like to survive the coming battle, you know."
         [/message]
 
         [message]
@@ -983,12 +983,12 @@
 
         [message]
             speaker=Isolde
-            message=_ "I want to return to a peaceful life when this war is done. First because of Garard and now because of these rebels, I've had to waste the best years of my life in bloodshed."
+            message=_ "I want to return to a peaceful life when this war is done. First because of Garard and now because of these rebels, I’ve had to waste the best years of my life in bloodshed."
         [/message]
 
         [message]
             speaker=Bazur 
-            message=_ "That's great! Peace is for weaklings!"
+            message=_ "That’s great! Peace is for weaklings!"
         [/message]
 
         [message]
@@ -1265,31 +1265,31 @@
                 speaker=Bazur 
                 message= _ "Looks like another Queen needs help from the orcs!"
                     [option]
-                        label= _ "Alright, I'll help you."
+                        label= _ "Alright, I’ll help you."
                         [command]
                             [message]
                                 speaker=Isolde
-                                message=_ "Are you crazy? We don't have time for this nonsense, we have to go to Dan'Tonk!"
+                                message=_ "Are you crazy? We don’t have time for this nonsense, we have to go to Dan’Tonk!"
                             [/message]
                             [message]
                                 speaker=Bazur
-                                message=_ "Don't fret, a bunch of ants is nothing against orcs, we won't be here long."
+                                message=_ "Don’t fret, a bunch of ants is nothing against orcs, we won’t be here long."
                             [/message]
 
                             [modify_side]
                                 side=3
                                 team_name=bazur 
-                                user_team_name=_ "Queen Chuchelka's Forces"
+                                user_team_name=_ "Queen Chuchelka’s Forces"
                             [/modify_side]
 
                             [modify_side]
                                 side=4
-                                user_team_name=_ "Evil Chuchelka's Forces"
+                                user_team_name=_ "Evil Chuchelka’s Forces"
                             [/modify_side]
 
                             [message]
                                 speaker=Dwarf
-                                message=_ "Thank you very much! The Queen Chuchelka says her subjects shalln't attack you anymore."
+                                message=_ "Thank you very much! The Queen Chuchelka says her subjects shalln’t attack you anymore."
                             [/message]
 
                             {VARIABLE_OP save_chu add 1}
@@ -1297,7 +1297,7 @@
                     [/option]
 
                     [option]
-                        label= _ "We don't have time for this."
+                        label= _ "We don’t have time for this."
                         [command]
 
                             [message]
@@ -1608,7 +1608,7 @@
                 message= _ "This cloak is made of shadows. If I wear it, I will be invisible to my enemies at night and underground! (the <i>nightstalk</i> ability)"
 
                 [option]
-                    label= _ "I'll wear it."
+                    label= _ "I’ll wear it."
 
                     [command]
 

--- a/scenarios/07_An_Underground_Feud.cfg
+++ b/scenarios/07_An_Underground_Feud.cfg
@@ -478,12 +478,12 @@
 
         [message]
             speaker=unit 
-            message=_ "Ahhh, they're everywhere!"
+            message=_ "Ahhh, they’re everywhere!"
         [/message]
 
         [message]
             speaker=Bazur
-            message=_ "Rebels, at last! My arms are getting stiff, well, let's warm up!"
+            message=_ "Rebels, at last! My arms are getting stiff, well, let’s warm up!"
         [/message]
 
         [message]
@@ -507,7 +507,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "Oh no, the passageway's blocked. Now... Now we have to travel through the holes dug by those critters."
+            message=_ "Oh no, the passageway’s blocked. Now... Now we have to travel through the holes dug by those critters."
         [/message]
 
         [message]
@@ -517,7 +517,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "Damn it, let's fight through one of the side tunnels. Quick!"
+            message=_ "Damn it, let’s fight through one of the side tunnels. Quick!"
         [/message]
     [/event]
 
@@ -540,12 +540,12 @@
 
             [message]
                 speaker=Isolde
-                message=_ "It's the gateway to the catacombs of Dan'Tonk. We made it! But it's locked — what do we do?"
+                message=_ "It’s the gateway to the catacombs of Dan’Tonk. We made it! But it’s locked — what do we do?"
             [/message]
 
             [message]
                 speaker=Bazur
-                message=_ "Just get me to that gate. I'll knock it down!"
+                message=_ "Just get me to that gate. I’ll knock it down!"
             [/message]
 
             [remove_event]
@@ -601,12 +601,12 @@
 
             [message]
                 speaker=Bazur
-                message=_ "What's that?"
+                message=_ "What’s that?"
             [/message]
 
             [message]
                 speaker=Isolde
-                message=_ "The royal army must be bombarding the city. The Queen's assault is about to begin — we must hurry."
+                message=_ "The royal army must be bombarding the city. The Queen’s assault is about to begin — we must hurry."
             [/message]
 
             [message]
@@ -677,12 +677,12 @@
         [message]
             side=5
             type=Lieutenant
-            message=_ "This is as far as you get, you usurper's dogs!"
+            message=_ "This is as far as you get, you usurper’s dogs!"
         [/message]
 
         [message]
             speaker=Isolde
-            message=_ "We'll see about that!"
+            message=_ "We’ll see about that!"
         [/message]
     [/event]
 
@@ -714,7 +714,7 @@
                     [/kill]
                     [message]
                         speaker=Bazur
-                        message=_ "Look, spoils of war! He dropped his fancy helmet, and it's barely dented. Someone should go pick it up."
+                        message=_ "Look, spoils of war! He dropped his fancy helmet, and it’s barely dented. Someone should go pick it up."
                     [/message]
 
                     {VARIABLE helmetX $x1}
@@ -725,7 +725,7 @@
                     
                     [message]
                         speaker=Isolde
-                        message=_ "You're incorrigible, Bazur."
+                        message=_ "You’re incorrigible, Bazur."
                     [/message]
                     
                     
@@ -816,9 +816,9 @@
                         [/filter]
                         [message]
                             speaker=unit
-                            message= _ "This helmet will protect me from blade and pierce (+10%) damage. I'll be braver to rush into the battlefield with it on! (+1 move)."
+                            message= _ "This helmet will protect me from blade and pierce (+10%) damage. I’ll be braver to rush into the battlefield with it on! (+1 move)."
                             [option]
-                                label= _ "I'll take it."
+                                label= _ "I’ll take it."
                                 [command]
                                     {REMOVE_IMAGE $helmetX $helmetY}
                                     [remove_event]
@@ -834,7 +834,7 @@
                                     [object]
                                         name=_"Royal Helm"
                                         image="icons/helmet_frogmouth.png"
-                                        description= _ "Only lightly dented, this gilded helm once belonged to the captain of Dan'tonk's swordsmen."
+                                        description= _ "Only lightly dented, this gilded helm once belonged to the captain of Dan’tonk’s swordsmen."
                                         duration=forever
                                         [filter]
                                             find_in=unit
@@ -855,7 +855,7 @@
                                 [/command]
                             [/option]
                             [option]
-                                label= _ "I'll leave this for someone else."
+                                label= _ "I’ll leave this for someone else."
                                 [command]
                                     [allow_undo] 
                                     [/allow_undo]
@@ -876,22 +876,22 @@
 
                     [message]
                         speaker=unit
-                        message=_ "I am Ron, commander of the swordsmen of Dan'Tonk. I served the Baron de Ferres. When the city was besieged, my lord sent me to the catacombs. Me and my best swordsmen to the catacombs!"
+                        message=_ "I am Ron, commander of the swordsmen of Dan’Tonk. I served the Baron de Ferres. When the city was besieged, my lord sent me to the catacombs. Me and my best swordsmen to the catacombs!"
                     [/message]
                     
                     [message]
                         speaker=unit
-                        message=_ "It was quiet at first, but then the bombardment started. The passageway collapsed, and out of the holes in the walls came these vile creatures! I don't know if it was the noise or what, but they just keep coming and coming, outnumbering us ten-to-one! Almost all my swordsmen died fighting them. I can't believe my lord would send us to such a horrible and ignominious death!"
+                        message=_ "It was quiet at first, but then the bombardment started. The passageway collapsed, and out of the holes in the walls came these vile creatures! I don’t know if it was the noise or what, but they just keep coming and coming, outnumbering us ten-to-one! Almost all my swordsmen died fighting them. I can’t believe my lord would send us to such a horrible and ignominious death!"
                     [/message]
 
                     [message]
                         speaker=Isolde
-                        message=_ "Dan'Tonk will soon be taken and de Ferres will be strung up on the gallows. Join us, Ron, we have a task worthy of your swordsmen."
+                        message=_ "Dan’Tonk will soon be taken and de Ferres will be strung up on the gallows. Join us, Ron, we have a task worthy of your swordsmen."
                     [/message]
 
                     [message]
                         speaker=unit
-                        message=_ "My lord ruined me, and you saved my life. I'll join you. De Ferres will regret treating us like fodder!"
+                        message=_ "My lord ruined me, and you saved my life. I’ll join you. De Ferres will regret treating us like fodder!"
                     [/message]
 
                     {TRANSFER_VILLAGE_OWNERSHIP 2 1} 
@@ -906,7 +906,7 @@
 
                     [object] 
                         silent=no
-                        name= _ "Ron's squad"
+                        name= _ "Ron’s squad"
                         image="units/human-loyalists/swordsman.png~RC(magenta>white)"
                         duration=scenario
                         description= _ "Ron has joined you. He is a leader, and can recruit Swordsmen when standing on a keep."
@@ -948,7 +948,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "It's quiet, let's go!"
+            message=_ "It’s quiet, let’s go!"
         [/message]
 
         [message]
@@ -998,7 +998,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "Sure I did! But every son is a bastard who will sooner or later try to kill you and take your place, so I'm glad I escaped from them!"
+            message=_ "Sure I did! But every son is a bastard who will sooner or later try to kill you and take your place, so I’m glad I escaped from them!"
         [/message]
 
         [message]
@@ -1008,7 +1008,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "Fret not. I'll have my grunts cover you more if you want to survive so badly! Now let's get up there — I can't wait to see this Dan'Tonk of yours, and to meet the chief rebel himself!"
+            message=_ "Fret not. I’ll have my grunts cover you more if you want to survive so badly! Now let’s get up there — I can’t wait to see this Dan’Tonk of yours, and to meet the chief rebel himself!"
         [/message]
 
         [endlevel]
@@ -1112,7 +1112,7 @@
 
         [message]
             speaker=Bazur 
-            message=_ "Fire creature's dead. Ugh, it's gotten all over my shoes."
+            message=_ "Fire creature’s dead. Ugh, it’s gotten all over my shoes."
         [/message]
 
         [if]
@@ -1156,7 +1156,7 @@
 
         [message]
             speaker=unit
-            message=_ "You'll regret killing us, you'll see."
+            message=_ "You’ll regret killing us, you’ll see."
         [/message]
     [/event]  
 
@@ -1195,7 +1195,7 @@
 
         [message]
             speaker=Dwarf
-            message=_ "For the Queen, of course. And she's in danger!"
+            message=_ "For the Queen, of course. And she’s in danger!"
         [/message]
 
         [message]
@@ -1215,22 +1215,22 @@
 
         [message]
             speaker=Dwarf
-            message=_ "What kind of Asheviere? We're talking about our Queen Chuchelka! And we don't give a damn about your surface squabbles."
+            message=_ "What kind of Asheviere? We’re talking about our Queen Chuchelka! And we don’t give a damn about your surface squabbles."
         [/message]
 
         [message]
             speaker=Isolde
-            message=_ "So you don't support the Wesnoth Crown?"
+            message=_ "So you don’t support the Wesnoth Crown?"
         [/message]
 
         [message]
             speaker=Mech
-            message=_ "We don't support anyone. We don't care about the crown of Wesnoth. We have our own war to fight, more important than yours."
+            message=_ "We don’t support anyone. We don’t care about the crown of Wesnoth. We have our own war to fight, more important than yours."
         [/message]
 
         [message]
             speaker=Isolde
-            message=_ "Bazur, cut them down. We can't advance with these crazies in the rear."
+            message=_ "Bazur, cut them down. We can’t advance with these crazies in the rear."
         [/message]
 
         [message]
@@ -1245,7 +1245,7 @@
 
         [message]
             speaker=Mech
-            message=_ "Until the False Chuchelka came! She's taken over the other end of the cave and now she wants to destroy our Queen!"
+            message=_ "Until the False Chuchelka came! She’s taken over the other end of the cave and now she wants to destroy our Queen!"
         [/message]
 
         [message]
@@ -1313,7 +1313,7 @@
 
             [message]
                 speaker=Bazur 
-                message=_ "We've already squashed some nasty ant Queen on the opposite side of the cave. I think it was the False Chuchelka."
+                message=_ "We’ve already squashed some nasty ant Queen on the opposite side of the cave. I think it was the False Chuchelka."
             [/message]
 
             [message]
@@ -1323,25 +1323,25 @@
 
             [message]
                 speaker=Isolde
-                message=_ "It's not worth wasting time talking to these madmen. Either slaughter them or move on to the end of the tunnel."
+                message=_ "It’s not worth wasting time talking to these madmen. Either slaughter them or move on to the end of the tunnel."
             [/message]
 
             [message]
                 speaker=Bazur 
                 message= _ "I think..."
                     [option]
-                        label= _ "All right, I'll accept your Queen's thanks."
+                        label= _ "All right, I’ll accept your Queen’s thanks."
                         [command]
 
                             [modify_side]
                                 side=3
                                 team_name=bazur 
-                                user_team_name=_ "Queen Chuchelka's Forces"
+                                user_team_name=_ "Queen Chuchelka’s Forces"
                             [/modify_side]
 
                             [modify_side]
                                 side=4
-                                user_team_name=_ "False Chuchelka's Forces"
+                                user_team_name=_ "False Chuchelka’s Forces"
                             [/modify_side]
 
                             [message]
@@ -1374,7 +1374,7 @@
                     [/option]
 
                     [option]
-                        label= _ "I don't need thanks from some stinky ants!"
+                        label= _ "I don’t need thanks from some stinky ants!"
                         [command]
 
                             [message]
@@ -1416,7 +1416,7 @@
         [message]
             scroll=no
             speaker=Bazur
-            message=_ "This bandit's club is no ordinary club!"
+            message=_ "This bandit’s club is no ordinary club!"
         [/message]
 
         {HIGHLIGHT_IMAGE $clubX $clubY items/club.png ()}
@@ -1442,7 +1442,7 @@
                 message= _ "That club inspires terror. With it, I can break the bones of my enemies with any weapon in my hands! (+1 melee damage and impact secondary damage type to melee attacks)."
 
                 [option]
-                    label= _ "I'll take it."
+                    label= _ "I’ll take it."
 
                     [command]
 
@@ -1517,7 +1517,7 @@
                 message= _ "That club inspires terror. With it, I can break the bones of my enemies with any weapon in my hands! (+1 melee damage and impact secondary damage type to melee attacks)."
 
                 [option]
-                    label= _ "I'll take it."
+                    label= _ "I’ll take it."
 
                     [command]
 
@@ -1539,7 +1539,7 @@
                         [object]
                             name= _ "Club of Terror"
                             image=attacks/mace-spiked.png
-                            description= _ "In the troll's hands, the Club of Terror has found its true power. The troll gains +1 to melee attacks!"
+                            description= _ "In the troll’s hands, the Club of Terror has found its true power. The troll gains +1 to melee attacks!"
 
                             [effect]
                                 apply_to=attack 
@@ -1582,7 +1582,7 @@
         [message]
             scroll=no
             speaker=Bazur
-            message=_ "This madman's cloak exudes dark power! Someone has to wear it!"
+            message=_ "This madman’s cloak exudes dark power! Someone has to wear it!"
         [/message]
 
         {VARIABLE dwarf_cloakX $unit.x}

--- a/scenarios/08_The_End_of_the_War.cfg
+++ b/scenarios/08_The_End_of_the_War.cfg
@@ -581,7 +581,7 @@
 
         [message]
             speaker=Leollyn
-            message=_ "(I never thought I'd live to serve a queen like this!)"
+            message=_ "(I never thought I’d live to serve a queen like this!)"
         [/message]
 
         {FIREBALL Leollyn 30 14}
@@ -604,7 +604,7 @@
         
         [message]
             speaker=Baron_Richard
-            message=_ "I'll tell you what to do: defend Dan'Tonk to our last drop of blood; be the rock against which Asheviere will break her teeth! They will tear themselves apart, they will run, and on their heels we will enter Weldyn, and you will recognize me as regent! Any objections?"
+            message=_ "I’ll tell you what to do: defend Dan’Tonk to our last drop of blood; be the rock against which Asheviere will break her teeth! They will tear themselves apart, they will run, and on their heels we will enter Weldyn, and you will recognize me as regent! Any objections?"
         [/message]
 
         [message]
@@ -614,12 +614,12 @@
 
         [message]
             speaker=Sir_Grey
-            message=_ "There's no turning back now; it's to Weldyn or to the grave. I'm with you, Richard!"
+            message=_ "There’s no turning back now; it’s to Weldyn or to the grave. I’m with you, Richard!"
         [/message]
 
         [message]
             speaker=Baron_Richard
-            message=_ "To the walls, then! Let's show this rebel scum that the spirit of Garard still lives!"
+            message=_ "To the walls, then! Let’s show this rebel scum that the spirit of Garard still lives!"
         [/message]
 
         [message]
@@ -846,7 +846,7 @@
 
         [message]
             speaker=unit 
-            message=_ "I'm opening the gates!"
+            message=_ "I’m opening the gates!"
         [/message]
 
         [terrain]
@@ -898,7 +898,7 @@
 
         [message]
             speaker=unit 
-            message=_ "I'm opening the gates!"
+            message=_ "I’m opening the gates!"
         [/message]
 
         [terrain]
@@ -922,7 +922,7 @@
         [message]
             side=2
             canrecruit=yes
-            message=_ "Soldiers, attack! Forward, and we shall end this war in de Ferres's citadel!"
+            message=_ "Soldiers, attack! Forward, and we shall end this war in de Ferres’s citadel!"
         [/message]
 
         [event]
@@ -946,7 +946,7 @@
 
         [message]
             speaker=Isolde
-            message=_ "I can't believe it. The war is over! I survived, I'll live to see peace!"
+            message=_ "I can’t believe it. The war is over! I survived, I’ll live to see peace!"
         [/message]
 
         {SCROLL_TO 1 1}
@@ -1132,7 +1132,7 @@
 
         [message]
             speaker=Asheviere 
-            message=_ "All the rebel leaders are dead and Dan'Tonk lies at my feet. To whom do I owe this triumph?"
+            message=_ "All the rebel leaders are dead and Dan’Tonk lies at my feet. To whom do I owe this triumph?"
         [/message]
 
         [message]
@@ -1197,7 +1197,7 @@
 
         [message]
             speaker=Asheviere 
-            message=_ "General Dommel, you were one of Garard's officers. At first, I doubted you. But you have proven your loyalty to the kingdom, not just to a person, and I appreciate that. In gratitude for your service, I appoint you commandant of Halstead Fortress, our great stronghold in the west."
+            message=_ "General Dommel, you were one of Garard’s officers. At first, I doubted you. But you have proven your loyalty to the kingdom, not just to a person, and I appreciate that. In gratitude for your service, I appoint you commandant of Halstead Fortress, our great stronghold in the west."
         [/message]
 
         [message]
@@ -1212,7 +1212,7 @@
 
         [message]
             speaker=Ghuvog
-            message=_ "Graah, my warriors and I will stay with all youse humans. After Garard, the saurians, and the rebels, there's not much left of Clan Blackcrest."
+            message=_ "Graah, my warriors and I will stay with all youse humans. After Garard, the saurians, and the rebels, there’s not much left of Clan Blackcrest."
         [/message]
 
         [message]
@@ -1433,7 +1433,7 @@
         #--------------------
         [message]
             speaker=Delfador
-            message=_ "I am not too late! De Ferres's colors still fly over Dan'Tonk!"
+            message=_ "I am not too late! De Ferres’s colors still fly over Dan’Tonk!"
         [/message]
         [message]
             speaker=Baron_Richard
@@ -1441,11 +1441,11 @@
         [/message]
         [message]
             speaker=Delfador
-            message=_ "Forgive me for the delay, de Ferres. I have been acting in secret, infiltrating Weldyn under Asheveire's very nose, and have only just returned from deep council with the elves of the Aethenwood. I bring good tidings - our hope for a king is not yet lost!"
+            message=_ "Forgive me for the delay, de Ferres. I have been acting in secret, infiltrating Weldyn under Asheveire’s very nose, and have only just returned from deep council with the elves of the Aethenwood. I bring good tidings - our hope for a king is not yet lost!"
         [/message]
         [message]
             speaker=Baron_Richard
-            message=_ "That's all well and good, but while you were off scheming we were fighting and getting surrounded in our own city! Enough talk — unleash your magic against Asheviere's rebels! This battle can yet be won!"
+            message=_ "That’s all well and good, but while you were off scheming we were fighting and getting surrounded in our own city! Enough talk — unleash your magic against Asheviere’s rebels! This battle can yet be won!"
         [/message]
         [message]
             speaker=Delfador 
@@ -1453,7 +1453,7 @@
         [/message]
         [message]
             speaker=Baron_Richard
-            message=_ "Do you suggest I abandon my own city? I shan't flee to some backwater port — Dan'Tonk is my home, and my home is where I shall stand. Wesnoth's fate will be decided here and now — stand with me against the dark queen!"
+            message=_ "Do you suggest I abandon my own city? I shan’t flee to some backwater port — Dan’Tonk is my home, and my home is where I shall stand. Wesnoth’s fate will be decided here and now — stand with me against the dark queen!"
         [/message]
         [message]
             speaker=Delfador 
@@ -1662,7 +1662,7 @@
             [/message]
             [message]
                 speaker=Isolde
-                message=_ "Court mage, hero of Wesnoth, “The Great”, et cetera. He was the one who turned the orcs and lizards against each other at the Ford of Abez, thereby ending Garard's War."
+                message=_ "Court mage, hero of Wesnoth, “The Great”, et cetera. He was the one who turned the orcs and lizards against each other at the Ford of Abez, thereby ending Garard’s War."
             [/message]
             [message]
                 speaker=Bazur
@@ -1670,7 +1670,7 @@
             [/message]
             [message]
                 speaker=Isolde
-                message=_ "Don't talk nonsense, concentrate on our mission! And prepare for the worst — if Delfador really is as strong as they say, the sky itself will soon fall upon us..."
+                message=_ "Don’t talk nonsense, concentrate on our mission! And prepare for the worst — if Delfador really is as strong as they say, the sky itself will soon fall upon us..."
             [/message]
             [show_objectives] # refresh objectives, showing the note about lightning
             [/show_objectives]
@@ -1693,11 +1693,11 @@
                 [/message]
                 [message]
                     speaker=Delfador
-                    message=_ "Leollyn, my old examiner. I can't believe my eyes! How can you fight by Asheviere's side after all she's done? She orchestrated Garard's assassination!"
+                    message=_ "Leollyn, my old examiner. I can’t believe my eyes! How can you fight by Asheviere’s side after all she’s done? She orchestrated Garard’s assassination!"
                 [/message]
                 [message]
                     speaker=Leollyn
-                    message=_ "Hmph! The way I hear it, you were more than complicit in those events. You forget that we are mages, not politicians. Whoever sits on the throne of Wesnoth, it's our duty to help them."
+                    message=_ "Hmph! The way I hear it, you were more than complicit in those events. You forget that we are mages, not politicians. Whoever sits on the throne of Wesnoth, it’s our duty to help them."
                 [/message]
                 [message]
                     speaker=Delfador
@@ -1741,7 +1741,7 @@
         [/filter_condition]
         [message]
             speaker=Baron_Richard
-            message= _ "What is this...? The commander of my city guard fights beneath the enemy's colours? Do my eyes deceive me?"
+            message= _ "What is this...? The commander of my city guard fights beneath the enemy’s colours? Do my eyes deceive me?"
         [/message]
         [message]
             speaker=Ron
@@ -1749,7 +1749,7 @@
         [/message]
         [message]
             speaker=Baron_Richard
-            message= _ "Proud fool, it is because the catacombs were this city's only weakness that I sent you to ward them! And for that you have betrayed our cause and the king's memory? So be it, viper, you shall do us less harm in Asheviere's camp than in our own."
+            message= _ "Proud fool, it is because the catacombs were this city’s only weakness that I sent you to ward them! And for that you have betrayed our cause and the king’s memory? So be it, viper, you shall do us less harm in Asheviere’s camp than in our own."
         [/message]
     [/event]
 

--- a/scenarios/08_The_End_of_the_War.cfg
+++ b/scenarios/08_The_End_of_the_War.cfg
@@ -60,7 +60,7 @@
 
     [label]
         x,y=16,12
-        text=_ "Dan'Tonk citadel"
+        text=_ "Dan’Tonk citadel"
         immutable=yes
     [/label]
 
@@ -163,7 +163,7 @@
         {BAZUR_ARC_I}
         color=white
         team_name=bazur
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT ragged}
         save_id=bazur
     [/side]
@@ -180,7 +180,7 @@
         recruit=Spearman,Pikeman,Javelineer,Bowman,Longbowman,Shock Trooper,Mage,Dragoon,Fencer,Cavalryman
         color=orange
         team_name=bazur
-        user_team_name= _ "Asheviere's Forces"
+        user_team_name= _ "Asheviere’s Forces"
         {FLAG_VARIANT loyalist}
         [ai]
             {NO_SCOUTS}
@@ -199,7 +199,7 @@
         income=10
         recruit=Spearman,Bowman,Heavy Infantryman,Fencer,Swordsman,Pikeman,Longbowman,Cavalryman,Dragoon,Javelineer,Mage,Lieutenant
         team_name=bazur
-        user_team_name=_"Asheviere's Forces"
+        user_team_name=_"Asheviere’s Forces"
         {FLAG_VARIANT loyalist}
         save_id=queen
         [ai]
@@ -219,7 +219,7 @@
         income=16
         recruit=Orcish Grunt,Orcish Archer,Orcish Assassin,Wolf Rider,Troll Whelp, Goblin Spearman,Orcish Warrior,Troll,Troll Rocklobber,Orcish Crossbowman,Goblin Knight,Goblin Impaler
         team_name=bazur
-        user_team_name=_"Asheviere's Forces"
+        user_team_name=_"Asheviere’s Forces"
         {FLAG_VARIANT ragged}
         [ai]
             {NO_SCOUTS}
@@ -794,7 +794,7 @@
 
         [message]
             speaker=unit 
-            message=_ "I'm opening the gates!"
+            message=_ "I’m opening the gates!"
         [/message]
 
         [terrain]
@@ -817,7 +817,7 @@
 
         [message]
             speaker=Ghuvog
-            message=_ "Attack! Let's pay back the pink-skins for their victory at Abez!"
+            message=_ "Attack! Let’s pay back the pink-skins for their victory at Abez!"
         [/message]
 
         [event]
@@ -1147,7 +1147,7 @@
 
         [message]
             speaker=Dommel
-            message=_ "We were only following Your Majesty's orders."
+            message=_ "We were only following Your Majesty’s orders."
         [/message]
 
         [message]
@@ -1257,7 +1257,7 @@
 
         [message]
             speaker=Asheviere 
-            message=_ "Much better. General Dommel, is Dan'Tonk's citadel still intact?"
+            message=_ "Much better. General Dommel, is Dan’Tonk’s citadel still intact?"
         [/message]
 
         [message]
@@ -1779,7 +1779,7 @@
 
             [message]
                 speaker=second_unit 
-                message=_ "It would have been better if we'd never met again, friend..."
+                message=_ "It would have been better if we’d never met again, friend..."
             [/message]
 
             [message]

--- a/utils/characters.cfg
+++ b/utils/characters.cfg
@@ -105,7 +105,7 @@
             add=100
             max_value=100
             name= _ "magnificent armour"
-            description= _ "Arrows, spears and throwing knives bounce off the Baron's magnificent armour without doing any damage. Ranged blade and pierce attacks on the Baron will reduce damage by 99%. 
+            description= _ "Arrows, spears and throwing knives bounce off the Baron’s magnificent armour without doing any damage. Ranged blade and pierce attacks on the Baron will reduce damage by 99%. 
 
     Moreover, the Baron cannot be poisoned or slowed."     
             affect_self=yes
@@ -167,12 +167,12 @@
 
         [message]
             speaker=unit 
-            message=_ "I'll never see the end of the war..."
+            message=_ "I’ll never see the end of the war..."
         [/message]
 
         [message]
             speaker=Bazur
-            message=_ "Now the Queen will think it was us who slaughtered the woman. We'll never be rewarded!"
+            message=_ "Now the Queen will think it was us who slaughtered the woman. We’ll never be rewarded!"
         [/message]
 
         [endlevel]

--- a/utils/loyals.cfg
+++ b/utils/loyals.cfg
@@ -237,7 +237,7 @@
 
             [message]
                 speaker=Moog 
-                message=_ "I'll shoot fire arrows and let everything burn!"
+                message=_ "I’ll shoot fire arrows and let everything burn!"
             [/message]
 
             [object]
@@ -316,7 +316,7 @@
 
         [message]
             speaker=Moog
-            message=_ "The sun won't stop me, I will destroy you!"
+            message=_ "The sun won’t stop me, I will destroy you!"
         [/message]
 
         {VARIABLE moog_attack yes}

--- a/utils/loyals.cfg
+++ b/utils/loyals.cfg
@@ -65,7 +65,7 @@
 
         [message]
             speaker=Gnork
-            message=_ "This crossbow is a coward's weapon! Shameful! Gnork will prove he is orc enough to fight with a sword like a real warrior!"
+            message=_ "This crossbow is a coward’s weapon! Shameful! Gnork will prove he is orc enough to fight with a sword like a real warrior!"
         [/message]
 
         [object]


### PR DESCRIPTION
Removed all non-curly apostrophes from translatable strings to abide with the official typography style guide.