### PR TITLE
S4: Capitalize Quintain

### DIFF
--- a/scenarios/04_A_Prophecy_in_the_Royal_Forest.cfg
+++ b/scenarios/04_A_Prophecy_in_the_Royal_Forest.cfg
@@ -101,17 +101,17 @@
         [then]
             [message]
                 speaker=unit 
-                message=_ "Ouch, the quintain is fighting! What the!"
+                message=_ "Ouch, the Quintain is fighting! What the!"
             [/message]
 
             [message]
                 speaker=Isolde 
-                message=_ "It’s a magic quintain, just like at the Royal Military Academy. The witch must have created it to train the peasants."
+                message=_ "It’s a magic Quintain, just like at the Royal Military Academy. The witch must have created it to train the peasants."
             [/message]
 
             [message]
                 speaker=unit 
-                message=_ "I don’t need training, but I’m gonna blow the quintain to smithereens!"
+                message=_ "I don’t need training, but I’m gonna blow the Quintain to smithereens!"
             [/message]
         [/then])}
 
@@ -120,12 +120,12 @@
         [then]
             [message]
                 speaker=unit 
-                message=_ "Ouch, it’s a magic quintain, the witch must have created it to train the peasants!"
+                message=_ "Ouch, it’s a magic Quintain, the witch must have created it to train the peasants!"
             [/message]
 
             [message]
                 speaker=Isolde 
-                message=_ "I hear they have quintains like this at the Royal Military Academy. Let’s see if I can pass this exam!"
+                message=_ "I hear they have Quintains like this at the Royal Military Academy. Let’s see if I can pass this exam!"
             [/message]
         [/then])}
     [/event]
@@ -146,7 +146,7 @@
             silent=no 
             icon="items/dummy.png~RC(magenta<brown)"
             duration=scenario 
-            description=_ "By defeating the quintain, the $second_unit.name gained the trait <i>trained</i>."
+            description=_ "By defeating the Quintain, the $second_unit.name gained the trait <i>trained</i>."
 
             [filter]
                 find_in=second_unit 


### PR DESCRIPTION
Quintain is a unit type, which should be capitalized according to the official typography style guide.