### PR TITLE
Replace Dan-Tonk with Dan’Tonk

### DIFF
--- a/scenarios/01_Orcish_Comradery.cfg
+++ b/scenarios/01_Orcish_Comradery.cfg
@@ -32,7 +32,7 @@
             {AD_BIGMAP}
         [/part]
         [part]
-            story= _ "In turn, lords loyal to Garard’s memory rallied together and began assembling an army great enough to all but ensure the usurper’s overthrow. Indeed, the queen’s position was dire, for though she controlled the province of Weldyn, rebel banners rose swiftly over the strongholds of Soradoc and Dan-Tonk. Encircled and soon to be outnumbered, Asheviere devised a cunning plan."
+            story= _ "In turn, lords loyal to Garard’s memory rallied together and began assembling an army great enough to all but ensure the usurper’s overthrow. Indeed, the queen’s position was dire, for though she controlled the province of Weldyn, rebel banners rose swiftly over the strongholds of Soradoc and Dan’Tonk. Encircled and soon to be outnumbered, Asheviere devised a cunning plan."
             background=story/landscape-hills-02.webp
         [/part]
         [part]

--- a/scenarios/06_The_Art_of_War.cfg
+++ b/scenarios/06_The_Art_of_War.cfg
@@ -26,7 +26,7 @@
         [/part]
 
         [part]
-            story=_ "Only the mighty baron of Dan-Tonk, Richard de Ferres, remained a credible threat to Asheviere’s rule. Even before Bazur and Isolde reached Tath, de Ferres and his allies had already arrived at Weldyn."
+            story=_ "Only the mighty baron of Dan’Tonk, Richard de Ferres, remained a credible threat to Asheviere’s rule. Even before Bazur and Isolde reached Tath, de Ferres and his allies had already arrived at Weldyn."
             {AD_BIGMAP}
             {JOURNEY_05_OLD}
         [/part]
@@ -370,7 +370,7 @@
 
             [message]
                 speaker=Asheviere
-                message=_ "...so I am commanding an orderly march on Dan-Tonk. If General Dommel has not failed me at Tath, we will soon have de Ferres surrounded. I want the rebel plague eradicated before the first snow."
+                message=_ "...so I am commanding an orderly march on Dan’Tonk. If General Dommel has not failed me at Tath, we will soon have de Ferres surrounded. I want the rebel plague eradicated before the first snow."
             [/message]
 
             [endlevel]


### PR DESCRIPTION
Dan’Tonk is much more commonly used in AD and the form used elsewhere, but I found a few instances of Dan-Tonk being used randomly instead, so I fixed them.
