### PR TITLE
Uncapitalize queen in Isolde last breath event

### DIFF
--- a/utils/characters.cfg
+++ b/utils/characters.cfg
@@ -172,7 +172,7 @@
 
         [message]
             speaker=Bazur
-            message=_ "Now the Queen will think it was us who slaughtered the woman. We’ll never be rewarded!"
+            message=_ "Now the queen will think it was us who slaughtered the woman. We’ll never be rewarded!"
         [/message]
 
         [endlevel]


### PR DESCRIPTION
Here, where it is not next to Asheviere, I see no need to capitalize queen. Generally the titles king and queen are uncapitalized under msot circumstances in Qesnoth, and probably should be here too.