### PR TITLE
Remove 6 Straight Apostrophes

### DIFF
--- a/achievements.cfg
+++ b/achievements.cfg
@@ -54,7 +54,7 @@
 
     [achievement]
         id=ad_chu_offical
-        name= _ "Scenario 8: Queen Chuchelka's Officals (hidden)"
+        name= _ "Scenario 8: Queen Chuchelka’s Officals (hidden)"
         description= _ "Open all gates with ant units in <i>The End of the War</i>"
         icon="data/core/images/attacks/fangs-ant.png~SCALE(72,72)"
         icon_completed="data/core/images/attacks/fangs-ant.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"

--- a/scenarios/04_A_Prophecy_in_the_Royal_Forest.cfg
+++ b/scenarios/04_A_Prophecy_in_the_Royal_Forest.cfg
@@ -516,7 +516,7 @@
                     carryover_add=yes
                 [/gold_carryover]
                 [note]
-                    description= _ "Bazur's starting position is considered Keep. On your first turn, you can recruit/recall units in the highlighted hexes."
+                    description= _ "Bazur’s starting position is considered Keep. On your first turn, you can recruit/recall units in the highlighted hexes."
                 [/note]
         [/objectives]   
     [/event]

--- a/units/Isolde_Squire.cfg
+++ b/units/Isolde_Squire.cfg
@@ -16,9 +16,9 @@
     advances_to=AD_Warrior_Commander
     cost=25
     usage=fighter
-    description= _ "Isolde was a squire of her husband, Sir Johan, a brave knight who had spent his life on campaigns and done many deeds for the glory of the Wesnoth Crown. He fought in Eldred's army at the Battle of Abez and defeated many orcs and trolls. When the rebellion began, Johan had no time to realise what had happened and was ignominiously killed by an arrow from Garard's supporters. 
+    description= _ "Isolde was a squire of her husband, Sir Johan, a brave knight who had spent his life on campaigns and done many deeds for the glory of the Wesnoth Crown. He fought in Eldred’s army at the Battle of Abez and defeated many orcs and trolls. When the rebellion began, Johan had no time to realise what had happened and was ignominiously killed by an arrow from Garard’s supporters. 
 
-During their time together, Johan taught Isolde many clever stratagems. Now she fights in Asheviere's army to confirm her knighthood. Though Isolde is inferior to the other commanders in both status and physical strength, she endeavours to be a proactive and brave soldier who might go on to achieve noteworthy feats... if she survives long enough."
+During their time together, Johan taught Isolde many clever stratagems. Now she fights in Asheviere’s army to confirm her knighthood. Though Isolde is inferior to the other commanders in both status and physical strength, she endeavours to be a proactive and brave soldier who might go on to achieve noteworthy feats... if she survives long enough."
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     {DEFENSE_ANIM_RANGE "units/human-loyalists/sergeant-defend.png" "units/human-loyalists/sergeant.png" {SOUND_LIST:HUMAN_FEMALE_HIT} melee}
     {DEFENSE_ANIM_RANGE "units/human-loyalists/sergeant-crossbow-defend.png" "units/human-loyalists/sergeant-crossbow.png" {SOUND_LIST:HUMAN_FEMALE_HIT} ranged}

--- a/units/Isolde_Warrior.cfg
+++ b/units/Isolde_Warrior.cfg
@@ -16,7 +16,7 @@
     advances_to=AD_Knight_Commander
     cost=40
     usage=fighter
-    description= _ "The longer Isolde fights in the royal army, the more her husband's traits, such as bravery, initiative, and indifference to the soldiers' hardships, emerge in her. Perhaps it is because of these qualities that the orcs of Bazur look upon her with less disdain than other humans."
+    description= _ "The longer Isolde fights in the royal army, the more her husband’s traits, such as bravery, initiative, and indifference to the soldiers' hardships, emerge in her. Perhaps it is because of these qualities that the orcs of Bazur look upon her with less disdain than other humans."
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     {DEFENSE_ANIM_RANGE "units/human-loyalists/lieutenant-defend-2.png" "units/human-loyalists/lieutenant-defend-1.png" {SOUND_LIST:HUMAN_FEMALE_HIT} melee}
     {DEFENSE_ANIM_RANGE "units/human-loyalists/lieutenant-crossbow-defend.png" "units/human-loyalists/lieutenant-crossbow.png" {SOUND_LIST:HUMAN_FEMALE_HIT} ranged}


### PR DESCRIPTION
I missed a few last time. Based on my github search, I think there shouldn’t be any others in translatable strings left after this.