### PR TITLE
Make names credited untransatable

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -30,49 +30,49 @@
     [about]
         title=_ "Campaign Design"
         [entry]
-            name=_ "Mechanical"
+            name="Mechanical"
         [/entry]
     [/about]
     [about]
         title=_ "Code Assistance"
         [entry]
-            name=_"ForestDragon"
+            name="ForestDragon"
         [/entry]
         [entry]
-            name=_"dwarftough"
+            name="dwarftough"
         [/entry]
         [entry]
-            name=_"Dalas"
+            name="Dalas"
         [/entry]
         [entry]
-            name=_"Jonathan Kelly"
+            name="Jonathan Kelly"
         [/entry]
     [/about]
     [about]
         title=_ "Text Assistance"
         [entry]
-            name=_"Dalas"
+            name="Dalas"
         [/entry]
         [entry]
-            name=_"Gothyoba"
+            name="Gothyoba"
         [/entry]
         [entry]
-            name=_"Jonathan Kelly"
+            name="Jonathan Kelly"
         [/entry]
     [/about]
     [about]
         title=_ "Testing"
         [entry]
-            name=_"ForestDragon"
+            name="ForestDragon"
         [/entry]
         [entry]
-            name=_"dwarftough"
+            name="dwarftough"
         [/entry]
         [entry]
-            name=_"Dalas"
+            name="Dalas"
         [/entry]
         [entry]
-            name=_"Jonathan Kelly"
+            name="Jonathan Kelly"
         [/entry]
     [/about]
 [/campaign]


### PR DESCRIPTION
Most mainline campaigns don’t translate these.